### PR TITLE
DEBUG: Deleting intermeadiate generated file.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
   "python.linting.enabled": true,
   "python.linting.pylintArgs": [
     "--load-plugins=nomad.metainfo.pylint_plugin",
-    "nexusutils",
+    "pynxtools",
     "tests"
   ],
   "python.testing.pytestArgs": ["tests"],

--- a/pynxtools/nyaml2nxdl/nyaml2nxdl.py
+++ b/pynxtools/nyaml2nxdl/nyaml2nxdl.py
@@ -45,7 +45,7 @@ def generate_nxdl_or_retrieve_nxdl(yaml_file, out_xml_file, verbose):
         Else, generate nxdl from separated yaml with the help of nyaml2nxdl function
     """
     pa_path, rel_file = os.path.split(yaml_file)
-    sep_yaml = pa_path + f'temp_{rel_file}'
+    sep_yaml = os.path.join(pa_path, f'temp_{rel_file}')
     hash_found = separate_hash_yaml_and_nxdl(yaml_file, sep_yaml, out_xml_file)
 
     if hash_found:
@@ -132,7 +132,7 @@ def split_name_and_extension(file_name):
     Split file name into extension and rest of the file name.
     return file raw nam and extension
     """
-    parts = file_name.rsplit('.', 2)
+    parts = file_name.rsplit('.', 3)
     if len(parts) == 2:
         raw = parts[0]
         ext = parts[1]

--- a/pynxtools/nyaml2nxdl/nyaml2nxdl_helper.py
+++ b/pynxtools/nyaml2nxdl/nyaml2nxdl_helper.py
@@ -28,6 +28,7 @@ which details a hierarchy of data/metadata elements
 # So the corresponding value is to skip them and
 # and also carefull about this order
 import hashlib
+import os
 from yaml.composer import Composer
 from yaml.constructor import Constructor
 
@@ -214,5 +215,7 @@ def separate_hash_yaml_and_nxdl(yaml_file, sep_yaml, sep_xml):
             # If the yaml fiile does not contain any hash for nxdl then we may have last line.
             if last_line:
                 yml_f_ob.write(last_line)
+    if not sha_hash:
+        os.remove(sep_xml)
 
     return sha_hash

--- a/tests/nyaml2nxdl/test_nyaml2nxdl.py
+++ b/tests/nyaml2nxdl/test_nyaml2nxdl.py
@@ -154,19 +154,25 @@ def test_fileline_error():
     In this test the yaml fileline in the error message is tested.
     """
     test_yml_file = 'tests/data/nyaml2nxdl/NXfilelineError1.yaml'
+    out_nxdl = 'tests/data/nyaml2nxdl/temp_NXfilelineError1.yaml'
     result = CliRunner().invoke(nyml2nxdl.launch_tool, ['--input-file', test_yml_file])
     assert result.exit_code == 1
     assert '13' in str(result.exception)
+    os.remove(out_nxdl)
 
     test_yml_file = 'tests/data/nyaml2nxdl/NXfilelineError2.yaml'
+    out_nxdl = 'tests/data/nyaml2nxdl/temp_NXfilelineError2.yaml'
     result = CliRunner().invoke(nyml2nxdl.launch_tool, ['--input-file', test_yml_file])
     assert result.exit_code == 1
     assert '21' in str(result.exception)
+    os.remove(out_nxdl)
 
     test_yml_file = 'tests/data/nyaml2nxdl/NXfilelineError3.yaml'
+    out_nxdl = 'tests/data/nyaml2nxdl/temp_NXfilelineError3.yaml'
     result = CliRunner().invoke(nyml2nxdl.launch_tool, ['--input-file', test_yml_file])
     assert result.exit_code == 1
     assert '25' in str(result.exception)
+    os.remove(out_nxdl)
 
     sys.stdout.write('Test on xml -> yml fileline error handling okay.\n')
 


### PR DESCRIPTION
Note: The temp files created in test 'test_fileline_error' mainly come from the intermediate step and the test was intended to fail. So, the created tmp file was not deleted as the entire process was not done. For that reason, the file has been created from the test by hard coding.