### PR TITLE
Transmission reader: Fixes reading of detector ranges

### DIFF
--- a/pynxtools/dataconverter/readers/json_yml/reader.py
+++ b/pynxtools/dataconverter/readers/json_yml/reader.py
@@ -49,7 +49,7 @@ class YamlJsonReader(BaseReader):
 
         sorted_paths = sorted(file_paths, key=lambda f: os.path.splitext(f)[1])
         for file_path in sorted_paths:
-            extension = os.path.splitext(file_path)[1]
+            extension = os.path.splitext(file_path)[1].lower()
             if extension not in self.extensions:
                 print(
                     f"WARNING: "

--- a/pynxtools/dataconverter/readers/transmission/reader.py
+++ b/pynxtools/dataconverter/readers/transmission/reader.py
@@ -33,10 +33,14 @@ from pynxtools.dataconverter.readers.utils import parse_json, parse_yml
 METADATA_MAP: Dict[str, Any] = {
     "/ENTRY[entry]/SAMPLE[sample]/name": 8,
     "/ENTRY[entry]/start_time": mpars.read_start_date,
-    "/ENTRY[entry]/instrument/sample_attenuator/attenuator_transmission": mpars.read_sample_attenuator,
-    "/ENTRY[entry]/instrument/ref_attenuator/attenuator_transmission": mpars.read_ref_attenuator,
-    "/ENTRY[entry]/instrument/spectrometer/GRATING[grating]/wavelength_range": mpars.read_uv_monochromator_range,
-    "/ENTRY[entry]/instrument/spectrometer/GRATING[grating1]/wavelength_range": mpars.read_visir_monochromator_range,
+    "/ENTRY[entry]/instrument/sample_attenuator/attenuator_transmission":
+        mpars.read_sample_attenuator,
+    "/ENTRY[entry]/instrument/ref_attenuator/attenuator_transmission":
+        mpars.read_ref_attenuator,
+    "/ENTRY[entry]/instrument/spectrometer/GRATING[grating]/wavelength_range":
+        mpars.read_uv_monochromator_range,
+    "/ENTRY[entry]/instrument/spectrometer/GRATING[grating1]/wavelength_range":
+        mpars.read_visir_monochromator_range,
     "/ENTRY[entry]/instrument/SOURCE[source]/type": "D2",
     "/ENTRY[entry]/instrument/SOURCE[source]/wavelength_range": mpars.get_d2_range,
     "/ENTRY[entry]/instrument/SOURCE[source1]/type": "halogen",


### PR DESCRIPTION
There was an error in the reading of asc files if the measurement was only performed in one detector range. In this case no separate slits, gain and times are noted in the file which was failing during reading of the file.