### PR TITLE
Adds test for example warnings and adds `--undocumented` flag

### DIFF
--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -64,7 +64,7 @@ def get_names_of_all_readers() -> List[str]:
     return all_readers
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,too-many-locals
 def convert(input_file: Tuple[str],
             reader: str,
             nxdl: str,

--- a/tests/data/dataconverter/readers/mpes/config_file.json
+++ b/tests/data/dataconverter/readers/mpes/config_file.json
@@ -339,12 +339,12 @@
   "/ENTRY[entry]/DATA[data]/@signal": "data",
   "/ENTRY[entry]/DATA[data]/data": "@data:data",
   "/ENTRY[entry]/DATA[data]/data/@units": "counts",
-  "/ENTRY[entry]/DATA[data]/VARIABLE[kx]": "@data:kx.data",
-  "/ENTRY[entry]/DATA[data]/VARIABLE[kx]/@units": "@data:kx.unit",
-  "/ENTRY[entry]/DATA[data]/VARIABLE[ky]": "@data:ky.data",
-  "/ENTRY[entry]/DATA[data]/VARIABLE[ky]/@units": "@data:ky.unit",
-  "/ENTRY[entry]/DATA[data]/VARIABLE[energy]": "@data:energy.data",
-  "/ENTRY[entry]/DATA[data]/VARIABLE[energy]/@units": "@data:energy.unit",
-  "/ENTRY[entry]/DATA[data]/VARIABLE[delay]": "@data:delay.data",
-  "/ENTRY[entry]/DATA[data]/VARIABLE[delay]/@units": "@data:delay.unit"
+  "/ENTRY[entry]/DATA[data]/AXISNAME[kx]": "@data:kx.data",
+  "/ENTRY[entry]/DATA[data]/AXISNAME[kx]/@units": "@data:kx.unit",
+  "/ENTRY[entry]/DATA[data]/AXISNAME[ky]": "@data:ky.data",
+  "/ENTRY[entry]/DATA[data]/AXISNAME[ky]/@units": "@data:ky.unit",
+  "/ENTRY[entry]/DATA[data]/AXISNAME[energy]": "@data:energy.data",
+  "/ENTRY[entry]/DATA[data]/AXISNAME[energy]/@units": "@data:energy.unit",
+  "/ENTRY[entry]/DATA[data]/AXISNAME[delay]": "@data:delay.data",
+  "/ENTRY[entry]/DATA[data]/AXISNAME[delay]/@units": "@data:delay.unit"
 }

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -21,7 +21,6 @@ import glob
 import os
 from typing import List
 import xml.etree.ElementTree as ET
-import logging
 
 import pytest
 from _pytest.mark.structures import ParameterSet
@@ -70,8 +69,9 @@ def test_if_readers_are_children_of_base_reader(reader):
     if reader.__name__ != "BaseReader":
         assert isinstance(reader(), BaseReader)
 
+
 @pytest.mark.parametrize("reader", get_all_readers())
-def test_has_correct_read_func(reader, caplog):
+def test_has_correct_read_func(reader):
     """Test if all readers have a valid read function implemented"""
     assert callable(reader.read)
     if reader.__name__ not in ["BaseReader"]:
@@ -118,6 +118,9 @@ def test_has_correct_read_func(reader, caplog):
     ])
 ])
 def test_shows_correct_warnings(reader_name, nxdl, undocumented_keys):
+    """
+    Checks whether the read function generates the correct warnings.
+    """
     def_dir = os.path.join(os.getcwd(), "pynxtools", "definitions")
     dataconverter_data_dir = os.path.join("tests", "data", "dataconverter")
 

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -105,17 +105,7 @@ def test_has_correct_read_func(reader):
 
 
 @pytest.mark.parametrize("reader_name,nxdl,undocumented_keys", [
-    ('mpes', 'NXmpes', [
-        '/@default',
-        '/ENTRY[entry]/DATA[data]/VARIABLE[kx]',
-        '/ENTRY[entry]/DATA[data]/VARIABLE[kx]/@units',
-        '/ENTRY[entry]/DATA[data]/VARIABLE[ky]',
-        '/ENTRY[entry]/DATA[data]/VARIABLE[ky]/@units',
-        '/ENTRY[entry]/DATA[data]/VARIABLE[energy]',
-        '/ENTRY[entry]/DATA[data]/VARIABLE[energy]/@units',
-        '/ENTRY[entry]/DATA[data]/VARIABLE[delay]',
-        '/ENTRY[entry]/DATA[data]/VARIABLE[delay]/@units',
-    ])
+    ('mpes', 'NXmpes', ['/@default'])
 ])
 def test_shows_correct_warnings(reader_name, nxdl, undocumented_keys):
     """

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -26,11 +26,9 @@ import logging
 import pytest
 from _pytest.mark.structures import ParameterSet
 
-from click.testing import CliRunner
-
 from pynxtools.dataconverter.readers.base.reader import BaseReader
 from pynxtools.dataconverter.convert import \
-    get_names_of_all_readers, get_reader, convert_cli
+    get_names_of_all_readers, get_reader
 from pynxtools.dataconverter.helpers import \
     validate_data_dict, generate_template_from_nxdl
 from pynxtools.dataconverter.template import Template


### PR DESCRIPTION
This ensures that changes do not change the warnings generated when converting the example files.

Currently, this is only for mpes but is parametrized and can be extended to other readers as well. We could also add this for all readers and add a script to generate the keys as a regression file to compare to.

It adds an `--undocumented` field, too. This enables the display of undocumented fields while writing the file. It also defaults to suppress warnings due to undocumented fields, but maybe it's better to default to showing them?