### PR TITLE
Changes nyaml2nxdl path in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
 [project.scripts]
 read_nexus = "pynxtools.nexus.nexus:main"
 dataconverter = "pynxtools.dataconverter.convert:convert_cli"
-nyaml2nxdl = "pynxtools.nyaml2nxdl.nyaml2nxdl:launch_tool"
+nyaml2nxdl = "pynxtools.definitions.dev_tools.nyaml2nxdl.nyaml2nxdl:launch_tool"
 generate_eln = "pynxtools.eln_mapper.eln_mapper:get_eln"
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Fixes #169 

- [ ] Change code references in py files
- [ ] Remove nyaml2nxdl from this repository and only use the one from nexus_definitions