### PR TITLE
Fix build via `python -m build`

### DIFF
--- a/pynxtools/_build_wrapper.py
+++ b/pynxtools/_build_wrapper.py
@@ -41,7 +41,7 @@ def get_vcs_version(tag_match="*[0-9]*") -> Optional[str]:
 def _write_version_to_metadata():
     version = get_vcs_version()
     if version is None or not version:
-        raise ValueError("Could not determine version from nexus_definitions")
+        return
 
     with open(
         os.path.join(os.path.dirname(__file__), "nexus-version.txt"),


### PR DESCRIPTION
This fixes the build via the python build method for wheel and sdist generation. It fails if the `nexus-version.txt` is not already present, so the code should just return to not write the file again if the code is not in a github repository anymore.
Previously, this was unnoticed because it works when the file was generated before.