### PR TITLE
Fix nexus version in published package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
The nexus version cannot be found in the published package, because we only shallowly checkout the repo.