### PR TITLE
Always install importlib-metadata (not only for <3.10) and provide dummy entry_points

### DIFF
--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -42,7 +42,8 @@ else:
     except ImportError:
         # If importlib_metadata is not present
         # we provide a dummy function just returning an empty list.
-        def entry_points(_):
+        # pylint: disable=W0613
+        def entry_points(group, _):
             """Dummy function for importlib_metadata"""
             return []
 

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -37,7 +37,14 @@ from pynxtools.nexus import nexus
 if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
 else:
-    from importlib_metadata import entry_points
+    try:
+        from importlib_metadata import entry_points
+    except ImportError:
+        # If importlib_metadata is not present
+        # we provide a dummy function just returning an empty list.
+        def entry_points(_):
+            """Dummy function for importlib_metadata"""
+            return []
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
@@ -59,7 +66,7 @@ def get_reader(reader_name) -> BaseReader:
         importlib_module = entry_points(group='pynxtools.reader')
         if (
             importlib_module
-            and reader_name in map(lambda ep: ep.name, entry_points(group='pynxtools.reader'))
+            and reader_name in map(lambda ep: ep.name, importlib_module)
         ):
             return importlib_module[reader_name].load()
         raise ValueError(f"The reader, {reader_name}, was not found.") from exc

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -43,7 +43,7 @@ else:
         # If importlib_metadata is not present
         # we provide a dummy function just returning an empty list.
         # pylint: disable=W0613
-        def entry_points(group, _):
+        def entry_points(group):
             """Dummy function for importlib_metadata"""
             return []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,9 @@ dependencies = [
     "lark>=1.1.5",
     "requests",
     "requests_cache",
-    "mergedeep"
+    "mergedeep",
+    "importlib-metadata",
 ]
-
-[options]
-install_requires = "importlib-metadata ; python_version < '3.10'"
 
 [project.urls]
 "Homepage" = "https://github.com/FAIRmat-NFDI/pynxtools"


### PR DESCRIPTION
The version dependent install of the backporting `importlib-metadata` sparked some problems with nomad's dependency resolving. Here, I bring that `importlib-metadata` is always installed, regardless of the python version.

It also provides a dummy `entry_points` if importlib-metadata cannot be imported.