### PR TITLE
Nomad Hotfix NeXus parsing

### DIFF
--- a/pynxtools/dataconverter/helpers.py
+++ b/pynxtools/dataconverter/helpers.py
@@ -607,7 +607,7 @@ def validate_data_dict(template, data, nxdl_root: ET.Element):
             # otherwise we just pass it along
             if (
                 elem is not None
-                and elem.attrib["name"] == entry_name
+                and elem.attrib.get("name") == entry_name
                 and remove_namespace_from_tag(elem.tag) in ("field", "attribute")
             ):
                 check_optionality_based_on_parent_group(


### PR DESCRIPTION
There is an error in nomad, which is probably due to the metainfo refactoring which runs into a keyerror. This fixes it.

We should go through the nomad metainfo and fix everything after the workshop. There are a lot of warnings and errors.