### PR TITLE
Fixes asterisk notation for mpes reader

### DIFF
--- a/pynxtools/dataconverter/readers/mpes/reader.py
+++ b/pynxtools/dataconverter/readers/mpes/reader.py
@@ -273,10 +273,7 @@ def fill_data_indices_in_config(config_file_dict, x_array_loaded):
                 new_key = key.replace("*", dim)
                 new_value = value.replace("*", dim)
 
-                if (
-                    new_key not in config_file_dict.keys()
-                    and new_value not in config_file_dict.values()
-                ):
+                if new_key not in config_file_dict.keys():
                     config_file_dict[new_key] = new_value
 
             config_file_dict.pop(key)


### PR DESCRIPTION
This PR should enable proper collection of axis names from xarray.
We use an asterisk for this to create key-value pairs:

```json
"/ENTRY[entry]/data": {
    "@axes": "@data:dims",
    "AXISNAME_indices[@*_indices]": "@data:*.index",
    "@signal": "data",
    "data": "@data:data",
    "data/@units": "counts",
    "AXISNAME[*]": "@data:*.data",
    "AXISNAME[*]/@units": "@data:*.unit",
    "energy/@type": "binding"
  }
```
, which creates, e.g., `AXISNAME[energy] = @data:energy.data` for all names in the data array.
We however, would like to be able to rename the key manually or enter a different value for the key. So if either the value or the key are present in the file the automatism should not write this particular entry. This manual overwriting does not work properly and needs to be fixed.