### PR TITLE
Update lint configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,12 +87,12 @@ local_scheme = "node-and-date"
 
 [tool.ruff]
 include = ["pynxtools/*.py", "tests/*.py"]
-select = [
+lint.select = [
     "E", # pycodestyle
     "W", # pycodestyle
     "PL", # pylint
 ]
-ignore = [
+lint.ignore = [
     "E501", # Line too long ({width} > {limit} characters)
     "E701", # Multiple statements on one line (colon)
     "E731", # Do not assign a lambda expression, use a def
@@ -107,7 +107,7 @@ ignore = [
     "PLR1714", # consider-using-in
     "PLR5501", # else-if-used
 ]
-fixable = ["ALL"]
+lint.fixable = ["ALL"]
 exclude = ["pynxtools/definitions/*"]
 
 [tool.mypy]


### PR DESCRIPTION
With newer ruff versions we get this warning

```
❯ ruff format .
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'fixable' -> 'lint.fixable'
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
141 files left unchanged
```

~Maybe we can also check the alignment with nomad here again. As I think some settings have changed there.~ I checked, we are still aligned with nomad (except for the version pinning).