### PR TITLE
String parsing and expression evaluation in json_map reader

### DIFF
--- a/pynxtools/dataconverter/readers/json_map/README.md
+++ b/pynxtools/dataconverter/readers/json_map/README.md
@@ -33,7 +33,7 @@ This file is designed to let you fill in the requirements of a NeXus Application
 The mapping files will always be based on the Template the dataconverter generates. See above on how to generate a mapping file.
 The right hand side values of the Template keys are what you can modify.
 
-Here are the three different ways you can fill the right hand side of the Template keys:
+Here are the different ways you can fill the right hand side of the Template keys:
 * Write the nested path in your datafile. This is indicated by a leading `/` before the word `entry` to make `/entry/data/current_295C` below. 
 Example:
 
@@ -97,6 +97,25 @@ The `datetime`, `dateutil` and `timestamp` properties are mutually exclusive.
 The resulting string replaces the mapped value (dictionary) in the mapping dictionary.
 If date parsing is enabled, the resulting string is ISO-formatted as required by the Nexus standard.
 
+* Python expression.
+The following entry creates an axis array from scalar values in the input file.
+
+```json
+  "/ENTRY[entry]/DATA[image]/angular0": {
+    "eval": "np.linspace(arg0[0], arg1[0], int(arg2[0]))",
+    "arg0": "/scan1/attrs/ScientaSliceBegin",
+    "arg1": "/scan1/attrs/ScientaSliceEnd",
+    "arg2": "/scan1/attrs/ScientaNumSlices"
+  },
+```
+
+The properties of the mapping declare the expression and its arguments.
+
+    "eval": (required) Python expression to be evaluated by the `eval` built-in.
+        The expression can use the built-in and numpy (as np) namespaces
+        as well as the datasets declared by the `argXxx` values.
+    "argXxx", where Xxx is an integer number: (optional) path of dataset to read from the input data
+        and to be used in the expression under the same name.
 
 ## Contact person in FAIRmat for this reader
 Sherjeel Shabih

--- a/pynxtools/dataconverter/readers/json_map/README.md
+++ b/pynxtools/dataconverter/readers/json_map/README.md
@@ -59,5 +59,44 @@ Note: This only works for HDF5 files currently.
   "/ENTRY[entry]/DATA[data]/current_300C": {"link": "current.nxs:/entry/data/current_300C"},
 ```
 
+* Convert custom date and time string to Nexus-compliant ISO format. 
+The following entry parses the date and time in a string array `/logs/logs` 
+with items like `22/10/22 15:18:26.0164 - Starting...`. 
+
+```json
+  "/ENTRY[entry]/end_time": {
+    "parse_string":  "/logs/logs",
+    "index": "-1",
+    "regexp": "[0-9.:/]+ [0-9.:/]+",
+    "dateutil": "dmy",
+    "timezone": "Europe/Berlin"
+  }
+```
+
+The properties correspond to operations that are applied to input data, in the order given below.
+The `datetime`, `dateutil` and `timestamp` properties are mutually exclusive.
+
+    "parse_string": (required) Data path of the string (array) like for regular datasets.
+    "index": (optional) Element index to extract from string array.
+        The original data must be a string array.
+        If this option is not specified, the original data must be a singular string.
+    "regexp": (optional) Match regular expression, keeping only the matching part.
+        If the expression contains groups, the result will be a space-delimited concatenation of the matching groups.
+        If the expression does not contain explicit groups, the whole match is used.
+    "datetime": (optional) Format string for datetime.datetime.strptime function.
+        If specified, use datetime.datetime.strptime for date parsing.
+    "dateutil": (optional) Date ordering for the dateutil.parser.parse function.
+        Possible values 'YMD', 'MDY', 'DMY' (or lower case).
+        The dateutil parsers recognizes many date and time formats, but may need the order of year, month and day.
+        If specified, use dateutil.parser.parse for date parsing.
+    "timestamp": (optional) Interpret the data item as POSIX timestamp.
+    "timezone": (optional) Specify the time zone if the date-time string does not include a UTC offset.
+        The time zone must be in a dateutil-supported format, e.g. "Europe/Berlin".
+        By default, the local time zone is used.
+
+The resulting string replaces the mapped value (dictionary) in the mapping dictionary.
+If date parsing is enabled, the resulting string is ISO-formatted as required by the Nexus standard.
+
+
 ## Contact person in FAIRmat for this reader
 Sherjeel Shabih

--- a/pynxtools/dataconverter/readers/json_map/reader.py
+++ b/pynxtools/dataconverter/readers/json_map/reader.py
@@ -185,6 +185,7 @@ def parse_strings(mapping, data):
         Possible values 'YMD', 'MDY', 'DMY' (or lower case).
         The dateutil parsers recognizes many date and time formats, but may need the order of year, month and day.
         The "datetime" and "dateutil" options are mutually exclusive.
+    "timestamp": (optional) Interpret the data item as POSIX timestamp.
     "timezone": (optional) Specify the time zone if the date-time string does not include a UTC offset.
         The time zone must be in a dateutil-supported format, e.g. "Europe/Berlin".
         By default, the local time zone is used.
@@ -229,6 +230,9 @@ def parse_strings(mapping, data):
             dt = dateutil.parser.parse(value, yearfirst=y < m, dayfirst=d < m)
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=tz)
+            value = dt.isoformat()
+        elif "timestamp" in parse_opts:
+            dt = datetime.datetime.fromtimestamp(float(value), tz=tz)
             value = dt.isoformat()
 
         mapping[key] = value


### PR DESCRIPTION
I propose two extensions of the json_map reader to handle custom date-time formats and expression evaluation. These changes serve the following use cases:

1. Nexus requires date and time specifications in ISO format. Older data files may use custom date formats such as mm/dd/yyyy or numeric time stamps. The proposed change allows to parse entries in the original data file using the Python datetime or dateutil libraries and convert them on the fly to ISO format.
2. Nexus requires coordinate axes to be given point-by-point. Some data files may specify only the end points, where the full array can be constructed using a numpy function, e.g. np.linspace. To be more general, the proposed code accepts any expression that can be evaluated using the eval built-in and the numpy library.

The proposed code introduces additional syntax to the json mapping file. It is fully backward compatible with existing mappings. Documentation in the code and README is included.