### PR TITLE
Fixes child retrieval for fields

### DIFF
--- a/pynxtools/dataconverter/helpers.py
+++ b/pynxtools/dataconverter/helpers.py
@@ -112,7 +112,7 @@ def get_all_defined_required_children(nxdl_path, nxdl_name):
 def add_inherited_children(list_of_children_to_add, path, nxdl_root, template):
     """Takes a list of child names and appends them to template for a given path."""
     for child in list_of_children_to_add:
-        child_path = f"{path.rsplit('/', 1)[0]}/{child}"
+        child_path = f"{path}/{child}"
         if child_path not in template.keys():
             optional_parent = check_for_optional_parent(child_path, nxdl_root)
             optionality = (
@@ -164,9 +164,9 @@ def generate_template_from_nxdl(
         ):
             template[optionality][f"{path}/@units"] = None
 
-        parent_path = convert_data_converter_dict_to_nxdl_path(path.rsplit("/", 1)[0])
+        nxdl_path = convert_data_converter_dict_to_nxdl_path(path)
         list_of_children_to_add = get_all_defined_required_children(
-            parent_path, nxdl_name
+            nxdl_path, nxdl_name
         )
         add_inherited_children(list_of_children_to_add, path, nxdl_root, template)
 

--- a/pynxtools/dataconverter/helpers.py
+++ b/pynxtools/dataconverter/helpers.py
@@ -482,6 +482,7 @@ def check_optionality_based_on_parent_group(path, nxdl_path, nxdl_root, data, te
 
 def is_group_part_of_path(path_to_group: str, path_of_entry: str) -> bool:
     """Returns true if a group is contained in a path"""
+
     tokens_group = path_to_group.split("/")
     tokens_entry = convert_data_converter_dict_to_nxdl_path(path_of_entry).split("/")
 
@@ -491,6 +492,7 @@ def is_group_part_of_path(path_to_group: str, path_of_entry: str) -> bool:
     for tog, toe in zip(tokens_group, tokens_entry):
         if tog != toe:
             return False
+
     return True
 
 
@@ -530,6 +532,7 @@ def ensure_all_required_fields_exist(template, data, nxdl_root):
             if not does_group_exist(renamed_path, data):
                 logger.warning(f"The required group, {path}, hasn't been supplied.")
                 continue
+            continue
         if not is_path_in_data_dict or data[renamed_path] is None:
             logger.warning(
                 f"The data entry corresponding to {path} is required "

--- a/pynxtools/dataconverter/helpers.py
+++ b/pynxtools/dataconverter/helpers.py
@@ -118,7 +118,7 @@ def add_inherited_children(list_of_children_to_add, path, nxdl_root, template):
             optionality = (
                 "required" if optional_parent == "<<NOT_FOUND>>" else "optional"
             )
-            template[optionality][f"{path.rsplit('/', 1)[0]}/{child}"] = None
+            template[optionality][f"{path}/{child}"] = None
     return template
 
 


### PR DESCRIPTION
This fixes the child retrievel which resulted in an error for non-existing fields, because parts of the nxdl paths were removed