### PR TITLE
Add a --get-required flag to the converter

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,10 +4,6 @@
 #
 #    pip-compile --extra=dev --extra=docs --output-file=dev-requirements.txt pyproject.toml
 #
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 asciitree==0.3.3
     # via zarr
 ase==3.22.1
@@ -40,10 +36,13 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
+    #   click-default-group
     #   dask
     #   mkdocs
     #   pip-tools
     #   pynxtools (pyproject.toml)
+click-default-group==1.2.4
+    # via pynxtools (pyproject.toml)
 cloudpickle==3.0.0
     # via dask
 colorama==0.4.6
@@ -53,16 +52,13 @@ comm==0.2.0
 contourpy==1.1.1
     # via matplotlib
 coverage[toml]==7.3.2
-    # via
-    #   coverage
-    #   pytest-cov
+    # via pytest-cov
 cycler==0.12.1
     # via matplotlib
 cython==3.0.6
     # via tables
 dask[array]==2023.5.0
     # via
-    #   dask
     #   hyperspy
     #   kikuchipy
     #   orix

--- a/pynxtools/dataconverter/README.md
+++ b/pynxtools/dataconverter/README.md
@@ -1,48 +1,58 @@
 # Dataconverter
 
-This tool contains a set of [readers](readers/) to convert supported data files into a compliant NeXus file.
+This tool converts experimental data to NeXus/HDF5 files based on any provided [NXDL schemas](https://manual.nexusformat.org/nxdl.html#index-1).
+It contains a set of [readers](readers/) to convert supported data files into a compliant NeXus file.
 
-You can read specific Readme's of the readers and find usage examples [here](../../examples/).
+You can read specific README's of the readers and find usage examples [here](../../examples/).
 
 ## Installation
 
 ```console
-user@box:~$ pip install git+https://github.com/FAIRmat-NFDI/pynxtools.git
+user@box:~$ pip install pynxtools
 ```
 
 ## Usage
 
-Converts experimental data to NeXus/HDF5 files based on any provided NXDL.
+### Commands
+- **convert**: This is the top-level command that allows you to use the converter. It can be called directly with ```dataconverter```.
+- **generate-template**: This command generates a reader template dictionary for a given NXDL file. It can be called with ```dataconverter generate-template```.
 
 ```console
 user@box:~$ dataconverter --help
-Usage: dataconverter [OPTIONS] [FILES]...
-
-  The CLI entrypoint for the convert function
+Usage: dataconverter [OPTIONS] COMMAND [ARGS]...
 
 Options:
+  --help                          Show this message and exit.
   --input-file TEXT               Deprecated: Please use the positional file
                                   arguments instead. The path to the input
                                   data file to read. (Repeat for more than one
                                   file.)
-  --reader [apm|ellips|em_nion|em_om|em_spctrscpy|example|hall|json_map|json_yml|rii_database|transmission|xps|xrd|mpes]
+  --reader [apm|ellips|em_nion|em_om|em_spctrscpy|example|hall|json_map|json_yml|mpes|sts|transmission|xps|xrd]
                                   The reader to use. default="example"
   --nxdl TEXT                     The name of the NXDL file to use without
                                   extension.This option is required if no '--
                                   params-file' is supplied.
   --output TEXT                   The path to the output NeXus file to be
                                   generated.
-  --generate-template             Just print out the template generated from
-                                  given NXDL file.
   --fair                          Let the converter know to be stricter in
                                   checking the documentation.
   --params-file FILENAME          Allows to pass a .yaml file with all the
                                   parameters the converter supports.
   --undocumented                  Shows a log output for all undocumented
                                   fields
+  --skip-verify                   Skips the verification routine during
+                                  conversion.
   --mapping TEXT                  Takes a <name>.mapping.json file and
                                   converts data from given input files.
-  --help                          Show this message and exit.
+
+Commands:
+  convert*           This command allows you to use the converter...
+  generate-template  Generates and prints a template to use for your nxdl.
+
+Info:
+  You can see more options by using --help for specific commands. For example:
+  dataconverter generate-template --help
+
 ```
 
 #### Merge partial NeXus files into one
@@ -57,7 +67,7 @@ user@box:~$ dataconverter --nxdl nxdl partial1.nxs partial2.nxs
 user@box:~$ dataconverter --nxdl nxdl any_data.hdf5 --mapping my_custom_map.mapping.json
 ```
 
-#### You can find actual examples with data files at [`examples/json_map`](../../examples/json_map/).
+You can find actual examples with data files at [`examples/json_map`](../../examples/json_map/).
 
 
 #### Use with multiple input files
@@ -69,10 +79,9 @@ user@box:~$ dataconverter --nxdl nxdl metadata data.raw otherfile
 ## Writing a Reader
 
 This converter allows extending support to other data formats by allowing extensions called readers.
-The converter provides a dev platform to build a NeXus compatible reader by providing checking
-against a chosen NeXus Application Definition.
+The converter provides a dev platform to build a NeXus compatible reader by providing checking against a chosen NeXus Application Definition.
 
-Readers have to be placed in the **readers** folder in there own subfolder.
+Readers have to be placed in the **readers** folder in their own subfolder.
 The reader folder should be named with the reader's name and contain a `reader.py`.\
 For example: The reader `Example Reader` is placed under [`readers/example/reader.py`](readers/example/reader.py).
 
@@ -111,17 +120,15 @@ READER = MyDataReader
 
 ```
 
-The read function takes a template dictionary based on the provided NXDL file (similar to `--generate-template`)
-and the list of all the file paths the user provides with `--input`.
+The read function takes a template dictionary based on the provided NXDL file (similar to `dataconverter generate-template`) and the list of all the file paths the user provides.
 The returned dictionary should contain keys that exist in the template as defined below.
 The values of these keys have to be data objects to be populated in the output NeXus file.
-They can be lists, numpy arrays, numpy bytes, numpy floats, numpy ints. Practically you can pass any value
-that can be handled by the `h5py` package.
+They can be lists, numpy arrays, numpy bytes, numpy floats, numpy ints. Practically you can pass any value that can be handled by the `h5py` package.
 
 The dataconverter can be executed using:
 
 ```console
-user@box:~$ dataconverter --reader mydata --nxdl NXmynxdl --output path_to_output.nxs
+user@box:~$ dataconverter --reader mydatareader --nxdl NXmynxdl --output path_to_output.nxs
 ```
 
 ### The reader template dictionary
@@ -164,6 +171,11 @@ You can also define links by setting the value to sub dictionary object with key
 
 ```python
 template["/entry/instrument/source"] = {"link": "/path/to/source/data"}
+```
+
+For a given NXDL schema, you can generate an empty template with the command
+```console
+user@box:~$ dataconverter generate-template` --nxdl NXmynxdl
 ```
 
 <img src="./convert_routine.svg" />

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -458,20 +458,20 @@ def convert_cli(
 )
 def generate_template(nxdl: str, required: bool, pythonic: bool, output: str):
     "Generates and prints a template to use for your nxdl."
-    print_or_write = print
+
+    def write_to_file(text):
+        f = open(output, "w")
+        f.write(text)
+        f.close()
+
+    print_or_write = lambda txt: write_to_file(txt) if output else print(txt)
+
     nxdl_root, nxdl_f_path = get_nxdl_root_and_path(nxdl)
     template = Template()
     helpers.generate_template_from_nxdl(nxdl_root, template)
 
     if required:
         template = Template(template.get_optionality("required"))
-
-    if output:
-
-        def print_or_write(text: str):
-            f = open(output, "w")
-            f.write(text)
-            f.close()
 
     if pythonic:
         print_or_write(str(template))

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -26,6 +26,7 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import List, Optional, Tuple
+import json
 
 import click
 from click_default_group import DefaultGroup
@@ -446,11 +447,29 @@ def convert_cli(
     help="Use this flag to only get the required template.",
     is_flag=True,
 )
-def generate_template(nxdl: str, required: bool):
+@click.option(
+    "--json",
+    "to_json",
+    help="Prints valid JSON instead of of a Pythonic str",
+    is_flag=True,
+)
+def generate_template(nxdl: str, required: bool, to_json: bool):
     "Generates and prints a template to use for your nxdl."
     nxdl_root, nxdl_f_path = get_nxdl_root_and_path(nxdl)
     template = Template()
     helpers.generate_template_from_nxdl(nxdl_root, template)
+
     if required:
         template = Template(template.get_optionality("required"))
+
+    if to_json:
+        print(
+            json.dumps(
+                template.get_accumulated_dict(),
+                indent=4,
+                sort_keys=True,
+                ensure_ascii=False,
+            )
+        )
+        return
     print(template)

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -448,13 +448,18 @@ def convert_cli(
     is_flag=True,
 )
 @click.option(
-    "--json",
-    "to_json",
-    help="Prints valid JSON instead of of a Pythonic str",
+    "--pythonic",
+    help="Prints a valid Python dictionary instead of JSON",
     is_flag=True,
 )
-def generate_template(nxdl: str, required: bool, to_json: bool):
+@click.option(
+    "--output",
+    help="Writes the output into the filepath provided.",
+    type=click.Path(),
+)
+def generate_template(nxdl: str, required: bool, pythonic: bool, output: str):
     "Generates and prints a template to use for your nxdl."
+    print_or_write = print
     nxdl_root, nxdl_f_path = get_nxdl_root_and_path(nxdl)
     template = Template()
     helpers.generate_template_from_nxdl(nxdl_root, template)
@@ -462,14 +467,21 @@ def generate_template(nxdl: str, required: bool, to_json: bool):
     if required:
         template = Template(template.get_optionality("required"))
 
-    if to_json:
-        print(
-            json.dumps(
-                template.get_accumulated_dict(),
-                indent=4,
-                sort_keys=True,
-                ensure_ascii=False,
-            )
-        )
+    if output:
+
+        def print_or_write(text: str):
+            f = open(output, "w")
+            f.write(text)
+            f.close()
+
+    if pythonic:
+        print_or_write(str(template))
         return
-    print(template)
+    print_or_write(
+        json.dumps(
+            template.get_accumulated_dict(),
+            indent=4,
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+    )

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -344,12 +344,6 @@ def main_cli():
     help="The path to the output NeXus file to be generated.",
 )
 @click.option(
-    "--generate-template",
-    is_flag=True,
-    default=False,
-    help="Just print out the template generated from given NXDL file.",
-)
-@click.option(
     "--fair",
     is_flag=True,
     default=False,
@@ -385,7 +379,6 @@ def convert_cli(
     reader: str,
     nxdl: str,
     output: str,
-    generate_template: bool,
     fair: bool,
     params_file: str,
     undocumented: bool,
@@ -446,6 +439,7 @@ def convert_cli(
     "--nxdl",
     default=None,
     help=("The name of the NXDL file to use without extension. For example: NXmpes"),
+    required=True,
 )
 @click.option(
     "--required",

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -293,7 +293,7 @@ class CustomClickGroup(DefaultGroup):
     ) -> None:
         """Writes all the options into the formatter if they exist."""
         opts = []
-        for param in self.get_params(ctx) + ctx.command.commands["convert"].params:
+        for param in self.get_params(ctx) + ctx.command.commands["convert"].params:  # type: ignore
             rv = param.get_help_record(ctx)
             if rv is not None:
                 opts.append(rv)

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -431,7 +431,6 @@ def convert_cli(
         fair,
         undocumented,
         skip_verify,
-        required,
     )
 
 

--- a/pynxtools/dataconverter/convert.py
+++ b/pynxtools/dataconverter/convert.py
@@ -218,6 +218,7 @@ def convert(
     fair: bool = False,
     undocumented: bool = False,
     skip_verify: bool = False,
+    required: bool = False,
     **kwargs,
 ):
     """The conversion routine that takes the input parameters and calls the necessary functions.
@@ -251,6 +252,8 @@ def convert(
     if generate_template:
         template = Template()
         helpers.generate_template_from_nxdl(nxdl_root, template)
+        if required:
+            template = Template(template.get_optionality("required"))
         print(template)
         return
 
@@ -354,6 +357,11 @@ def parse_params_file(params_file):
     "--mapping",
     help="Takes a <name>.mapping.json file and converts data from given input files.",
 )
+@click.option(
+    "--required",
+    help="Use this flag to with --generate-template to only get the required template.",
+    is_flag=True,
+)
 # pylint: disable=too-many-arguments
 def convert_cli(
     files: Tuple[str, ...],
@@ -367,6 +375,7 @@ def convert_cli(
     undocumented: bool,
     skip_verify: bool,
     mapping: str,
+    required: bool,
 ):
     """The CLI entrypoint for the convert function"""
     if params_file:
@@ -413,4 +422,5 @@ def convert_cli(
         fair,
         undocumented,
         skip_verify,
+        required,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=7.1.2",
+    "click_default_group",
     "h5py>=3.6.0",
     "xarray>=0.20.2",
     "PyYAML>=6.0",
@@ -84,7 +85,7 @@ stm = [
 
 [project.scripts]
 read_nexus = "pynxtools.nexus.nexus:main"
-dataconverter = "pynxtools.dataconverter.convert:convert_cli"
+dataconverter = "pynxtools.dataconverter.convert:main_cli"
 generate_eln = "pynxtools.eln_mapper.eln_mapper:get_eln"
 
 [tool.setuptools.package-data]

--- a/tests/dataconverter/test_convert.py
+++ b/tests/dataconverter/test_convert.py
@@ -117,7 +117,7 @@ def test_cli(caplog, cli_inputs):
     result = runner.invoke(dataconverter.main_cli, cli_inputs)
     if "generate-template" in cli_inputs:
         assert result.exit_code == 0
-        assert '"/ENTRY[entry]/NXODD_name/int_value": "None",' in result.stdout
+        assert '"/ENTRY[entry]/NXODD_name/int_value": null,' in result.stdout
     elif "--input-file" in cli_inputs:
         assert "test_input" in caplog.text
     elif result.exit_code == 2:

--- a/tests/dataconverter/test_convert.py
+++ b/tests/dataconverter/test_convert.py
@@ -104,9 +104,7 @@ def test_get_names_of_all_readers():
 @pytest.mark.parametrize(
     "cli_inputs",
     [
-        pytest.param(
-            ["--nxdl", "NXtest", "--generate-template"], id="generate-template"
-        ),
+        pytest.param(["generate-template", "--nxdl", "NXtest"], id="generate-template"),
         pytest.param([], id="nxdl-not-provided"),
         pytest.param(
             ["--nxdl", "NXtest", "--input-file", "test_input"], id="input-file"
@@ -116,8 +114,8 @@ def test_get_names_of_all_readers():
 def test_cli(caplog, cli_inputs):
     """A test for the convert CLI."""
     runner = CliRunner()
-    result = runner.invoke(dataconverter.convert_cli, cli_inputs)
-    if "--generate-template" in cli_inputs:
+    result = runner.invoke(dataconverter.main_cli, cli_inputs)
+    if "generate-template" in cli_inputs:
         assert result.exit_code == 0
         assert '"/ENTRY[entry]/NXODD_name/int_value": "None",' in result.stdout
     elif "--input-file" in cli_inputs:


### PR DESCRIPTION
I changed the flag to --required. I think we can use it to enforce more of the conversion routine to just focus on required fields in later versions.

This also has to be used with --generate-template right now. So if you do:

```console
dataconverter --nxdl NXmpes --generate-template --required
```

you will get the required fields.

I'm open to suggestions here. Let me know what can be improved and I'll add to it. 

- [x] Check if optional groups are not slipping through when the --required flag is used.
They are slipped through. Needs another MR as other verification routines can be affected by this.

_Partially_ fixes #264 as well.