### PR TITLE
Support for appdef extends

### DIFF
--- a/src/pynxtools/data/NXtest_extended.nxdl.xml
+++ b/src/pynxtools/data/NXtest_extended.nxdl.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+<definition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
+    xmlns="http://definition.nexusformat.org/nxdl/3.1"
+ name="NXtest_extended"
+ extends="NXtest"
+ type="group"
+ category="application"
+>
+    <doc>This is a dummy NXDL to test an extended application definition.</doc>
+    <group type="NXentry">
+        <field name="definition">
+            <doc>This is a dummy NXDL to test out the dataconverter.</doc>
+            <enumeration>
+                <item value="NXtest_extended"/>
+            </enumeration>
+        </field>
+        <field name="extended_field" type="NX_FLOAT" units="NX_ENERGY">
+            <doc>A dummy entry for an extended field.</doc>
+        </field>
+    </group>
+</definition>

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -194,7 +194,20 @@ def get_nxdl_name_from_elem(xml_element) -> str:
 
 
 def get_nxdl_name_for(xml_elem: ET._Element) -> Optional[str]:
-    """Get the name of the element from the NXDL element."""
+    """
+    Get the name of the element from the NXDL element.
+    For an entity having a name this is just the name.
+    For groups it is the uppercase type without NX, e.g. "ENTRY" for "NXentry".
+
+    Args:
+        xml_elem (ET._Element): The xml element to get the name for.
+
+    Returns:
+        Optional[str]:
+            The name of the element.
+            None if the xml element has no name or type attribute.
+    """
+    """"""
     if "name" in xml_elem.attrib:
         return xml_elem.attrib["name"]
     if "type" in xml_elem.attrib:
@@ -203,15 +216,41 @@ def get_nxdl_name_for(xml_elem: ET._Element) -> Optional[str]:
 
 
 def get_appdef_root(xml_elem: ET._Element) -> ET._Element:
+    """
+    Get the root element of the tree of xml_elem
+
+    Args:
+        xml_elem (ET._Element): The element for which to get the root element.
+
+    Returns:
+        ET._Element: The root element of the tree.
+    """
     return xml_elem.getroottree().getroot()
 
 
 def is_appdef(xml_elem: ET._Element) -> bool:
+    """
+    Check whether the xml element is part of an application definition.
+
+    Args:
+        xml_elem (ET._Element): The xml_elem whose tree to check.
+
+    Returns:
+        bool: True if the xml_elem is part of an application definition.
+    """
     return get_appdef_root(xml_elem).attrib.get("category") == "application"
 
 
 def get_all_parents_for(xml_elem: ET._Element) -> List[ET._Element]:
-    """Get all parents extends from the nxdl."""
+    """
+    Get all parents from the nxdl (via extends keyword)
+
+    Args:
+        xml_elem (ET._Element): The element to get the parents for.
+
+    Returns:
+        List[ET._Element]: The list of parents xml nodes.
+    """
     root = get_appdef_root(xml_elem)
     inheritance_chain = []
     extends = root.get("extends")

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -193,6 +193,36 @@ def get_nxdl_name_from_elem(xml_element) -> str:
     return name_to_add
 
 
+def get_nxdl_name_for(xml_elem: ET._Element) -> Optional[str]:
+    """Get the name of the element from the NXDL element."""
+    if "name" in xml_elem.attrib:
+        return xml_elem.attrib["name"]
+    if "type" in xml_elem.attrib:
+        return convert_nexus_to_caps(xml_elem.attrib["type"])
+    return None
+
+
+def get_appdef_root(xml_elem: ET._Element) -> ET._Element:
+    return xml_elem.getroottree().getroot()
+
+
+def is_appdef(xml_elem: ET._Element) -> bool:
+    return get_appdef_root(xml_elem).attrib.get("category") == "application"
+
+
+def get_all_parents_for(xml_elem: ET._Element) -> List[ET._Element]:
+    """Get all parents extends from the nxdl."""
+    root = get_appdef_root(xml_elem)
+    inheritance_chain = []
+    extends = root.get("extends")
+    while extends is not None and extends != "NXobject":
+        parent_xml_root, _ = get_nxdl_root_and_path(extends)
+        extends = parent_xml_root.get("extends")
+        inheritance_chain.append(parent_xml_root)
+
+    return inheritance_chain
+
+
 def get_nxdl_root_and_path(nxdl: str):
     """Get xml root element and file path from nxdl name e.g. NXapm.
 

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -282,16 +282,20 @@ def get_nxdl_root_and_path(nxdl: str):
     FileNotFoundError
         Error if no file with the given nxdl name is found.
     """
+
     # Reading in the NXDL and generating a template
     definitions_path = nexus.get_nexus_definitions_path()
-    if nxdl == "NXtest":
-        nxdl_f_path = os.path.join(
-            f"{os.path.abspath(os.path.dirname(__file__))}/../",
-            "data",
-            "NXtest.nxdl.xml",
-        )
-    elif nxdl == "NXroot":
-        nxdl_f_path = os.path.join(definitions_path, "base_classes", "NXroot.nxdl.xml")
+    data_path = os.path.join(
+        f"{os.path.abspath(os.path.dirname(__file__))}/../",
+        "data",
+    )
+    special_names = {
+        "NXtest": os.path.join(data_path, "NXtest.nxdl.xml"),
+        "NXtest_extended": os.path.join(data_path, "NXtest_extended.nxdl.xml"),
+    }
+
+    if nxdl in special_names:
+        nxdl_f_path = special_names[nxdl]
     else:
         nxdl_f_path = os.path.join(
             definitions_path, "contributed_definitions", f"{nxdl}.nxdl.xml"

--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -145,7 +145,10 @@ class NexusNode(NodeMixin):
             return
         if self.inheritance[0].attrib.get("recommended"):
             self.optionality = "recommended"
-        elif self.inheritance[0].attrib.get("optional"):
+        elif (
+            self.inheritance[0].attrib.get("optional")
+            or self.inheritance[0].attrib.get("minOccurs") == "0"
+        ):
             self.optionality = "optional"
 
     def __init__(

--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -701,6 +701,7 @@ def generate_tree_from(appdef: str) -> NexusNode:
     add_children_to(tree, entry)
 
     # Add all fields and attributes from the parent appdefs
-    populate_tree_from_parents(tree)
+    if len(appdef_inheritance_chain) > 1:
+        populate_tree_from_parents(tree)
 
     return tree

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -31,6 +31,7 @@ from pynxtools.dataconverter.helpers import (
     Collector,
     ValidationProblem,
     collector,
+    convert_nexus_to_caps,
     is_valid_data_field,
 )
 from pynxtools.dataconverter.nexus_tree import (
@@ -186,8 +187,14 @@ def validate_dict_against(
     """
 
     def get_variations_of(node: NexusNode, keys: Mapping[str, Any]) -> List[str]:
-        if not node.variadic and node.name in keys:
-            return [node.name]
+        if not node.variadic:
+            if node.name in keys:
+                return [node.name]
+            elif (
+                hasattr(node, "nx_class")
+                and f"{convert_nexus_to_caps(node.nx_class)}[{node.name}]" in keys
+            ):
+                return [f"{convert_nexus_to_caps(node.nx_class)}[{node.name}]"]
 
         variations = []
         for key in keys:

--- a/tests/dataconverter/test_nexus_tree.py
+++ b/tests/dataconverter/test_nexus_tree.py
@@ -1,6 +1,8 @@
-from typing import get_args
+from typing import Any, List, Tuple, get_args
 
+from anytree import Resolver
 from pynxtools.dataconverter.nexus_tree import (
+    NexusNode,
     NexusType,
     NexusUnitCategory,
     generate_tree_from,
@@ -31,3 +33,49 @@ def test_if_all_types_are_present():
     pydantic_literal_values = get_args(NexusType)
 
     assert set(reference_types) == set(pydantic_literal_values)
+
+
+def test_correct_extension_of_tree():
+    nxtest = generate_tree_from("NXtest")
+    nxtest_extended = generate_tree_from("NXtest_extended")
+
+    def get_node_fields(tree: NexusNode) -> List[Tuple[str, Any]]:
+        return list(
+            filter(
+                lambda x: not x[0].startswith("_") and x[0] not in "inheritance",
+                tree.__dict__.items(),
+            )
+        )
+
+    def left_tree_in_right_tree(left_tree, right_tree):
+        for left_child in left_tree.children:
+            if left_child.name not in map(lambda x: x.name, right_tree.children):
+                return False
+            right_child = list(
+                filter(lambda x: x.name == left_child.name, right_tree.children)
+            )[0]
+            if left_child.name == "definition":
+                # Definition should be overwritten
+                if not left_child.items == ["NXTEST", "NXtest"]:
+                    return False
+                if not right_child.items == ["NXtest_extended"]:
+                    return False
+                continue
+            for field in get_node_fields(left_child):
+                if field not in get_node_fields(right_child):
+                    return False
+            if not left_tree_in_right_tree(left_child, right_child):
+                return False
+        return True
+
+    assert left_tree_in_right_tree(nxtest, nxtest_extended)
+
+    resolver = Resolver("name", relax=True)
+    extended_field = resolver.get(nxtest_extended, "ENTRY/extended_field")
+    assert extended_field is not None
+    assert extended_field.unit == "NX_ENERGY"
+    assert extended_field.dtype == "NX_FLOAT"
+    assert extended_field.optionality == "required"
+
+    nxtest_field = resolver.get(nxtest, "ENTRY/extended_field")
+    assert nxtest_field is None


### PR DESCRIPTION
This adds support for the extends keyword for application definitions.

TODO:
- [x] Add test case with NXtest using the `extends` keyword and add tests for it
- [x] Fix NXellipsometry problems
- [x] Check NXxps
- [X] Check NXmpes_arpes