### PR TITLE
Add workflow for checking against NOMAD dependencies

### DIFF
--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout NOMAD from GitLab
       run: |
         git clone https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
-        cd nomad-FAIR
+        cd nomad
         git checkout develop 
 
     - name: Set up Python

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -17,12 +17,11 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Checkout NOMAD from GitLab
-      with:
-        submodules: 'recursive'
       run: |
         git clone https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
         cd nomad
         git checkout develop
+        git submodule update --init --recursive
     
     - name: Replace pynxtools dependency in NOMAD pyproject.toml
       run: |

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -1,0 +1,58 @@
+name: validate NOMAD dependencies compatibility
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate_nomad_dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout pynxtools
+      uses: actions/checkout@v2
+
+    - name: Checkout NOMAD from GitLab
+      run: |
+        git clone https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
+        cd nomad-FAIR
+        git checkout develop 
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'  # or any other version you need
+
+    - name: Parse pynxtools pyproject.toml
+      id: parse_pyproject
+      run: |
+        python -c "
+          import toml
+          import json# Load the pyproject.toml
+        
+          with open('pyproject.toml', 'r') as file:
+              pyproject = toml.load(file)
+        
+          dependencies = pyproject.get('project', {}).get('dependencies', [])
+        
+          # Convert to requirements format and save
+          with open('pyproject-requirements.txt', 'w') as f:
+              for dep in dependencies:
+                  f.write(f'{dep}\n')"
+    
+    - name: Combine and Check Dependencies
+      run: |
+        # Combine repo1's requirements with repo2's dependencies from pyproject.toml
+        cat nomad/requirements-dev > combined-requirements.txt
+        echo "" >> combined-requirements.txt
+        cat pyproject-requirements.txt >> combined-requirements.txt
+
+        # Upgrade pip and install the combined dependencies
+        python -m pip install --upgrade pip
+        pip install -r combined-requirements.txt
+      env:
+        PYTHONPATH: ""  # Ensure no pre-installed packages interfere with the test

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -27,32 +27,24 @@ jobs:
       with:
         python-version: '3.9'  # or any other version you need
 
-    - name: Parse pynxtools pyproject.toml
-      id: parse_pyproject
+    - name: Install pip-tools
       run: |
-        python -c "
-          import toml
-          import json# Load the pyproject.toml
+        python -m pip install --upgrade pip
+        pip install pip-tools
+
+    - name: Compile pyproject.toml to requirements.txt
+      run: |
+        # Use pip-compile to generate requirements.txt from pyproject.toml
+        pip-compile pyproject.toml --output-file=pyproject-requirements.txt
         
-          with open('pyproject.toml', 'r') as file:
-              pyproject = toml.load(file)
-        
-          dependencies = pyproject.get('project', {}).get('dependencies', [])
-        
-          # Convert to requirements format and save
-          with open('pyproject-requirements.txt', 'w') as f:
-              for dep in dependencies:
-                  f.write(f'{dep}\n')"
-    
     - name: Combine and Check Dependencies
       run: |
-        # Combine repo1's requirements with repo2's dependencies from pyproject.toml
+        # Combine NOMADS requirements with pynxtools dependencies from pyproject.toml
         cat nomad/requirements-dev > combined-requirements.txt
         echo "" >> combined-requirements.txt
         cat pyproject-requirements.txt >> combined-requirements.txt
 
-        # Upgrade pip and install the combined dependencies
-        python -m pip install --upgrade pip
+        # Install the combined dependencies
         pip install -r combined-requirements.txt
       env:
         PYTHONPATH: ""  # Ensure no pre-installed packages interfere with the test

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -1,4 +1,4 @@
-name: Validate Dependencies Compatibility
+name: validate Dependencies compatibility
 
 on:
   push:

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Replace pynxtools dependency in NOMAD pyproject.toml
       working-directory: ./nomad
       run: |
-        sed -i 's|pynxtools\[convert\]==0.3.1|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref }}|' pyproject.toml
+            sed -i "s|pynxtools\\\[convert\\\].*|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref }}|" pyproject.toml
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -24,6 +24,10 @@ jobs:
         cd nomad
         git checkout develop
 
+    - name: Init NOMAD submodules
+      run:
+        git submodule update --init --recursive
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Combine and Check Dependencies
       run: |
         # Combine NOMADS requirements with pynxtools dependencies from pyproject.toml
-        cat nomad/requirements-dev > combined-requirements.txt
+        cat nomad/requirements-dev.txt > combined-requirements.txt
         echo "" >> combined-requirements.txt
         cat pyproject-requirements.txt >> combined-requirements.txt
 

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -22,10 +22,8 @@ jobs:
 
     - name: Checkout NOMAD from GitLab
       run: |
-        git clone https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
-        cd nomad
-        git checkout develop
-        git submodule update --init --recursive
+        git clone --depth 1 --branch develop --recurse-submodules https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
+        git submodule update --init --recursive --depth 1
     
     - name: Replace pynxtools dependency in NOMAD pyproject.toml
       working-directory: ./nomad

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Replace pynxtools dependency in NOMAD pyproject.toml
       working-directory: ./nomad
       run: |
-            sed -i "s|pynxtools\\\[convert\\\].*|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref }}|" pyproject.toml
+        sed -i 's|pynxtools\[convert\]==[0-9]\+\(\.[0-9]\+\)\{0,2\}|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref }}|' pyproject.toml
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -1,4 +1,4 @@
-name: validate NOMAD dependencies compatibility
+name: Validate Dependencies Compatibility
 
 on:
   push:
@@ -9,42 +9,45 @@ on:
       - master
 
 jobs:
-  validate_nomad_dependencies:
+  validate_dependencies:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout pynxtools
+    - name: Checkout pynxtools (current repository)
       uses: actions/checkout@v2
 
     - name: Checkout NOMAD from GitLab
+      env:
+        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         git clone https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
         cd nomad
-        git checkout develop 
+        git checkout develop
 
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'  # or any other version you need
+        python-version: '3.9'
 
-    - name: Install pip-tools
+    - name: Install uv
       run: |
-        python -m pip install --upgrade pip
-        pip install pip-tools
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: Replace pynxtools dependency in NOMAD pyproject.toml
+      run: |
+        sed -i 's|pynxtools\[convert\]==0.3.1|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref }}|' pyproject.toml
 
-    - name: Compile pyproject.toml to requirements.txt
+    - name: Generate requirements.txt from pyproject.toml
       run: |
-        # Use pip-compile to generate requirements.txt from pyproject.toml
-        pip-compile pyproject.toml --output-file=pyproject-requirements.txt
-        
-    - name: Combine and Check Dependencies
-      run: |
-        # Combine NOMADS requirements with pynxtools dependencies from pyproject.toml
-        cat nomad/requirements-dev.txt > combined-requirements.txt
-        echo "" >> combined-requirements.txt
-        cat pyproject-requirements.txt >> combined-requirements.txt
+        uv pip compile -p 3.9 --annotation-style=line --extra=infrastructure --extra=parsing --output-file=requirements.txt dependencies/nomad-dos-fingerprints/pyproject.toml dependencies/parsers/eelsdb/pyproject.toml pyproject.toml
+        uv pip compile -p 3.9 --annotation-style=line --extra=dev --extra=infrastructure --extra=parsing --output-file=requirements-dev.txt requirements.txt pyproject.toml
 
-        # Install the combined dependencies
-        pip install -r combined-requirements.txt
+    - name: Install NOMAD dependencies with pynxtools from current branch
+      run: |
+        uv pip install --system -r requirements.txt
+        uv pip install --system -r requirements-dev.txt
       env:
         PYTHONPATH: ""  # Ensure no pre-installed packages interfere with the test
+
+    - name: Run Tests
+      run: |
+        pytest

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -3,10 +3,10 @@ name: validate NOMAD dependencies compatibility
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   validate_nomad_dependencies:

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -1,4 +1,4 @@
-name: validate Dependencies compatibility
+name: NOMAD dependencies compatibility
 
 on:
   push:
@@ -8,9 +8,9 @@ on:
     branches:
       - master
     # Run workflow only when there are changes in pyproject.toml or dev-requirements.txt
-    # paths:
-    # - 'pyproject.toml'
-    # - 'dev-requirements.txt'
+    paths:
+      - 'pyproject.toml'
+      - 'dev-requirements.txt'
 
 jobs:
   validate_dependencies:

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -13,20 +13,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout pynxtools (current repository)
+    - name: Checkout pynxtools
       uses: actions/checkout@v2
 
     - name: Checkout NOMAD from GitLab
-      env:
-        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+      with:
+        submodules: 'recursive'
       run: |
         git clone https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
         cd nomad
         git checkout develop
-
-    - name: Init NOMAD submodules
-      run:
-        git submodule update --init --recursive
+    
+    - name: Replace pynxtools dependency in NOMAD pyproject.toml
+      run: |
+        sed -i 's|pynxtools\[convert\]==0.3.1|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref }}|' pyproject.toml
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -35,12 +35,9 @@ jobs:
 
     - name: Install uv
       run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-    - name: Replace pynxtools dependency in NOMAD pyproject.toml
-      run: |
-        sed -i 's|pynxtools\[convert\]==0.3.1|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref }}|' pyproject.toml
+        curl -LsSf https://astral.sh/uv/install.sh | sh 
 
-    - name: Generate requirements.txt from pyproject.toml
+    - name: Generate (dev-)requirements.txt from modified pyproject.toml
       run: |
         uv pip compile -p 3.9 --annotation-style=line --extra=infrastructure --extra=parsing --output-file=requirements.txt dependencies/nomad-dos-fingerprints/pyproject.toml dependencies/parsers/eelsdb/pyproject.toml pyproject.toml
         uv pip compile -p 3.9 --annotation-style=line --extra=dev --extra=infrastructure --extra=parsing --output-file=requirements-dev.txt requirements.txt pyproject.toml

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - master
+    # Run workflow only when there are changes in pyproject.toml or dev-requirements.txt
+    # paths:
+    # - 'pyproject.toml'
+    # - 'dev-requirements.txt'
 
 jobs:
   validate_dependencies:
@@ -24,6 +28,7 @@ jobs:
         git submodule update --init --recursive
     
     - name: Replace pynxtools dependency in NOMAD pyproject.toml
+      working-directory: ./nomad
       run: |
         sed -i 's|pynxtools\[convert\]==0.3.1|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref }}|' pyproject.toml
 
@@ -37,17 +42,15 @@ jobs:
         curl -LsSf https://astral.sh/uv/install.sh | sh 
 
     - name: Generate (dev-)requirements.txt from modified pyproject.toml
+      working-directory: ./nomad
       run: |
         uv pip compile -p 3.9 --annotation-style=line --extra=infrastructure --extra=parsing --output-file=requirements.txt dependencies/nomad-dos-fingerprints/pyproject.toml dependencies/parsers/eelsdb/pyproject.toml pyproject.toml
         uv pip compile -p 3.9 --annotation-style=line --extra=dev --extra=infrastructure --extra=parsing --output-file=requirements-dev.txt requirements.txt pyproject.toml
 
     - name: Install NOMAD dependencies with pynxtools from current branch
+      working-directory: ./nomad
       run: |
         uv pip install --system -r requirements.txt
         uv pip install --system -r requirements-dev.txt
       env:
         PYTHONPATH: ""  # Ensure no pre-installed packages interfere with the test
-
-    - name: Run Tests
-      run: |
-        pytest


### PR DESCRIPTION
This is a draft for how we can make sure that the dependencies in the pyproject.toml file are in line with the NOMAD dependencies.

Strategy:
~~- [x] pip-compile pyproject.toml to a requirements file~~
~~- checkout NOMAD requirements from GitLab~~
~~- Combine the two requirements file and try to install the combined file~~
EDIT:
- check out NOMAD@develop and init all its submodules
- in nomad/pyproject.toml, replace the pynxtools[convert]==<version> by pynxtools[convert]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@<this-current-branch> to check if the current branch makes any problematic changes
- use NOMADS `uv pip compile` to generate the requirements-(dev).txt
- try to install these


Possible improvements:
- [x] only run this workflow if the pyproject.toml has actually changed
- [x] return possibly resolving dependencies

Fixes #85 