### PR TITLE
Validation fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "h5py>=3.6.0",
     "xarray>=0.20.2",
     "PyYAML>=6.0",
-    "numpy>=1.21.2",
+    "numpy>=1.21.2,<2.0.0.",
     "pandas>=1.3.2",
     "ase>=3.19.0",
     "mergedeep",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "h5py>=3.6.0",
     "xarray>=0.20.2",
     "PyYAML>=6.0",
-    "numpy>=1.21.2,<2.0.0.",
+    "numpy>=1.21.2,<2.0.0",
     "pandas>=1.3.2",
     "ase>=3.19.0",
     "mergedeep",

--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -415,7 +415,7 @@ class NexusNode(NodeMixin):
             )
             if not inherited_elem and name is not None:
                 # Try to namefit
-                groups = elem.xpath(
+                groups = elem.findall(
                     f"nx:group[@type='{xml_elem.attrib['type']}']",
                     namespaces=namespaces,
                 )

--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -552,7 +552,7 @@ class NexusGroup(NexusNode):
         for sibling in self.parent.get_all_direct_children_names(
             node_type=self.type, nx_class=self.nx_class
         ):
-            if sibling == self.name:
+            if sibling == self.name or not contains_uppercase(sibling):
                 continue
             if get_nx_namefit(sibling, self.name) >= -1:
                 fit = self.parent.search_child_with_name(sibling)

--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -438,7 +438,7 @@ class NexusNode(NodeMixin):
             if not xml_elem:
                 # Find group by naming convention
                 xml_elem = elem.xpath(
-                    f"*[self::nx:group][@type='NX{name.lower()}']",
+                    f"*[self::nx:group][@type='NX{name.lower()}' and not(@name)]",
                     namespaces=namespaces,
                 )
             if xml_elem:

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -504,11 +504,7 @@ def validate_dict_against(
             if best_name is None:
                 return False
 
-            resolver = Resolver("name", relax=True)
-            child_node = resolver.get(node, best_name)
-            node = (
-                node.add_inherited_node(best_name) if child_node is None else child_node
-            )
+            node = node.search_child_with_name(best_name)
 
         if isinstance(mapping[key], dict) and "link" in mapping[key]:
             # TODO: Follow link and check consistency with current field

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -206,7 +206,7 @@ def validate_dict_against(
                 continue
             if (
                 get_nx_namefit(name2fit, node.name) >= 0
-                and key not in node.parent.get_all_children_names()
+                and key not in node.parent.get_all_direct_children_names()
             ):
                 variations.append(key)
             if nx_name is not None and not variations:
@@ -239,7 +239,7 @@ def validate_dict_against(
                 data_node = node.search_child_with_name((signal, "DATA"))
                 data_bc_node = node.search_child_with_name("DATA")
                 data_node.inheritance.append(data_bc_node.inheritance[0])
-                for child in data_node.get_all_children_names():
+                for child in data_node.get_all_direct_children_names():
                     data_node.search_child_with_name(child)
 
                 handle_field(
@@ -271,7 +271,7 @@ def validate_dict_against(
                     axis_node = node.search_child_with_name((axis, "AXISNAME"))
                     axis_bc_node = node.search_child_with_name("AXISNAME")
                     axis_node.inheritance.append(axis_bc_node.inheritance[0])
-                    for child in axis_node.get_all_children_names():
+                    for child in axis_node.get_all_direct_children_names():
                         axis_node.search_child_with_name(child)
 
                     handle_field(
@@ -499,7 +499,7 @@ def validate_dict_against(
             return True
 
         for name in key[1:].replace("@", "").split("/"):
-            children = node.get_all_children_names()
+            children = node.get_all_direct_children_names()
             best_name = best_namefit_of(name, children)
             if best_name is None:
                 return False
@@ -608,7 +608,7 @@ def populate_full_tree(node: NexusNode, max_depth: Optional[int] = 5, depth: int
         # but it does while recursing the tree and it should
         # be fixed.
         return
-    for child in node.get_all_children_names():
+    for child in node.get_all_direct_children_names():
         child_node = node.search_child_with_name(child)
         populate_full_tree(child_node, max_depth=max_depth, depth=depth + 1)
 

--- a/tests/dataconverter/test_nexus_tree.py
+++ b/tests/dataconverter/test_nexus_tree.py
@@ -42,7 +42,8 @@ def test_correct_extension_of_tree():
     def get_node_fields(tree: NexusNode) -> List[Tuple[str, Any]]:
         return list(
             filter(
-                lambda x: not x[0].startswith("_") and x[0] not in "inheritance",
+                lambda x: not x[0].startswith("_")
+                and x[0] not in ("inheritance", "is_a", "parent_of"),
                 tree.__dict__.items(),
             )
         )

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -21,46 +21,49 @@ from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 import pytest
-
 from pynxtools.dataconverter.validation import validate_dict_against
 
 
 def get_data_dict():
     return {
-        "/my_entry/optional_parent/required_child": 1,
-        "/my_entry/optional_parent/optional_child": 1,
-        "/my_entry/nxodd_name/float_value": 2.0,
-        "/my_entry/nxodd_name/float_value/@units": "nm",
-        "/my_entry/nxodd_name/bool_value": True,
-        "/my_entry/nxodd_name/bool_value/@units": "",
-        "/my_entry/nxodd_name/int_value": 2,
-        "/my_entry/nxodd_name/int_value/@units": "eV",
-        "/my_entry/nxodd_name/posint_value": np.array([1, 2, 3], dtype=np.int8),
-        "/my_entry/nxodd_name/posint_value/@units": "kg",
-        "/my_entry/nxodd_name/char_value": "just chars",
-        "/my_entry/nxodd_name/char_value/@units": "",
-        "/my_entry/nxodd_name/type": "2nd type",
-        "/my_entry/nxodd_name/date_value": "2022-01-22T12:14:12.05018+00:00",
-        "/my_entry/nxodd_name/date_value/@units": "",
-        "/my_entry/nxodd_two_name/bool_value": True,
-        "/my_entry/nxodd_two_name/bool_value/@units": "",
-        "/my_entry/nxodd_two_name/int_value": 2,
-        "/my_entry/nxodd_two_name/int_value/@units": "eV",
-        "/my_entry/nxodd_two_name/posint_value": np.array([1, 2, 3], dtype=np.int8),
-        "/my_entry/nxodd_two_name/posint_value/@units": "kg",
-        "/my_entry/nxodd_two_name/char_value": "just chars",
-        "/my_entry/nxodd_two_name/char_value/@units": "",
-        "/my_entry/nxodd_two_name/type": "2nd type",
-        "/my_entry/nxodd_two_name/date_value": "2022-01-22T12:14:12.05018+00:00",
-        "/my_entry/nxodd_two_name/date_value/@units": "",
-        "/my_entry/my_group/required_field": 1,
-        "/my_entry/definition": "NXtest",
-        "/my_entry/definition/@version": "2.4.6",
-        "/my_entry/program_name": "Testing program",
-        "/my_entry/my_group/optional_field": 1,
-        "/my_entry/required_group/description": "An example description",
-        "/my_entry/required_group2/description": "An example description",
-        "/my_entry/optional_parent/req_group_in_opt_group/data": 1,
+        "/ENTRY[my_entry]/optional_parent/required_child": 1,
+        "/ENTRY[my_entry]/optional_parent/optional_child": 1,
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value": 2.0,
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value/@units": "nm",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/bool_value": True,
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/bool_value/@units": "",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/int_value": 2,
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/int_value/@units": "eV",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/posint_value": np.array(
+            [1, 2, 3], dtype=np.int8
+        ),
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/posint_value/@units": "kg",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/char_value": "just chars",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/char_value/@units": "",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/type": "2nd type",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/date_value": "2022-01-22T12:14:12.05018+00:00",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_name]/date_value/@units": "",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/bool_value": True,
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/bool_value/@units": "",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/int_value": 2,
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/int_value/@units": "eV",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/posint_value": np.array(
+            [1, 2, 3], dtype=np.int8
+        ),
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/posint_value/@units": "kg",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/char_value": "just chars",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/char_value/@units": "",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/type": "2nd type",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/date_value": "2022-01-22T12:14:12.05018+00:00",
+        "/ENTRY[my_entry]/NXODD_name[nxodd_two_name]/date_value/@units": "",
+        "/ENTRY[my_entry]/OPTIONAL_group[my_group]/required_field": 1,
+        "/ENTRY[my_entry]/definition": "NXtest",
+        "/ENTRY[my_entry]/definition/@version": "2.4.6",
+        "/ENTRY[my_entry]/program_name": "Testing program",
+        "/ENTRY[my_entry]/OPTIONAL_group[my_group]/optional_field": 1,
+        "/ENTRY[my_entry]/required_group/description": "An example description",
+        "/ENTRY[my_entry]/required_group2/description": "An example description",
+        "/ENTRY[my_entry]/optional_parent/req_group_in_opt_group/data": 1,
         "/@default": "Some NXroot attribute",
     }
 
@@ -86,7 +89,9 @@ def alter_dict(new_values: Dict[str, Any], data_dict: Dict[str, Any]) -> Dict[st
     [
         pytest.param(get_data_dict(), id="valid-unaltered-data-dict"),
         pytest.param(
-            remove_from_dict("/my_entry/nxodd_name/float_value", get_data_dict()),
+            remove_from_dict(
+                "/ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value", get_data_dict()
+            ),
             id="removed-optional-value",
         ),
     ],
@@ -101,8 +106,10 @@ def test_valid_data_dict(caplog, data_dict):
     "data_dict, error_message",
     [
         pytest.param(
-            remove_from_dict("/my_entry/nxodd_name/bool_value", get_data_dict()),
-            "The data entry corresponding to /my_entry/nxodd_name/bool_value is required and hasn't been supplied by the reader.",
+            remove_from_dict(
+                "/ENTRY[my_entry]/NXODD_name[nxodd_name]/bool_value", get_data_dict()
+            ),
+            "The data entry corresponding to /ENTRY[my_entry]/NXODD_name[nxodd_name]/bool_value is required and hasn't been supplied by the reader.",
             id="missing-required-value",
         )
     ],


### PR DESCRIPTION
# Fixes

- An issue when entries are search by naming convention (i.e., `ENTRY` for `NXentry`). Previously, it ignored if the found group has an actual name. This lead to wrong groups being returned.
- Attaching sub-groups correctly in their parent concepts, i.e., `my_data(NXdata)` is contains `DATA(NXdata)` if the latter is part of a super-concept of the current appdef
- Validation support if a specialised concept is given for for a required variadic group
- Pins `numpy<2.0.0`