### PR TITLE
Small typo and docstring fixes

### DIFF
--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -228,6 +228,20 @@ class NexusNode(NodeMixin):
     def search_add_child_for_multiple(
         self, names: Tuple[str, ...]
     ) -> Optional["NexusNode"]:
+        """
+        Searchs and adds a child with one of the names in `names` to the current node.
+        This calls `search_add_child_for` repeatedly until a child is found.
+        The found child is then returned.
+
+        Args:
+            name (Tuple[str, ...]):
+                A tuple of names of the child to search for.
+
+        Returns:
+            Optional["NexusNode"]:
+                The first matching NexusNode for the child name.
+                If no child is found at all None is returned.
+        """
         for name in names:
             child = self.search_add_child_for(name)
             if child is not None:

--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -37,7 +37,6 @@ from anytree.node.nodemixin import NodeMixin
 from pynxtools.dataconverter.helpers import (
     contains_uppercase,
     get_all_parents_for,
-    get_nxdl_name_for,
     get_nxdl_root_and_path,
     is_appdef,
     remove_namespace_from_tag,

--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -295,14 +295,10 @@ class NexusNode(NodeMixin):
                 The NexusNode containing the children.
                 None if there is no initialised children for the xml_node.
         """
-        return next(
-            (
-                x
-                for x in self.children
-                if x.inheritance and x.inheritance[0] == xml_elem
-            ),
-            None,
-        )
+        for child in self.children:
+            if child.inheritance and child.inheritance[0] == xml_elem:
+                return child
+        return None
 
     def get_all_direct_children_names(
         self,

--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -644,8 +644,11 @@ class NexusGroup(NexusNode):
                     0,
                 )
 
-                if required_children >= min_occurs:
-                    self.optionality = "optional"
+                if (
+                    sibling_node.optionality == "required"
+                    and required_children >= min_occurs
+                ):
+                    sibling_node.optionality = "optional"
 
     def _set_occurence_limits(self):
         """

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -236,14 +236,14 @@ def validate_dict_against(
                 # if the concept for signal is already defined in the appdef
                 # TODO: This appends the base class multiple times
                 # it should be done only once
-                data_node = node.search_child_with_name((signal, "DATA"))
-                data_bc_node = node.search_child_with_name("DATA")
+                data_node = node.search_add_child_for_multiple((signal, "DATA"))
+                data_bc_node = node.search_add_child_for("DATA")
                 data_node.inheritance.append(data_bc_node.inheritance[0])
                 for child in data_node.get_all_direct_children_names():
-                    data_node.search_child_with_name(child)
+                    data_node.search_add_child_for(child)
 
                 handle_field(
-                    node.search_child_with_name((signal, "DATA")),
+                    node.search_add_child_for_multiple((signal, "DATA")),
                     keys,
                     prev_path=prev_path,
                 )
@@ -268,14 +268,14 @@ def validate_dict_against(
                     # if the concept for the axis is already defined in the appdef
                     # TODO: This appends the base class multiple times
                     # it should be done only once
-                    axis_node = node.search_child_with_name((axis, "AXISNAME"))
-                    axis_bc_node = node.search_child_with_name("AXISNAME")
+                    axis_node = node.search_add_child_for_multiple((axis, "AXISNAME"))
+                    axis_bc_node = node.search_add_child_for("AXISNAME")
                     axis_node.inheritance.append(axis_bc_node.inheritance[0])
                     for child in axis_node.get_all_direct_children_names():
-                        axis_node.search_child_with_name(child)
+                        axis_node.search_add_child_for(child)
 
                     handle_field(
-                        node.search_child_with_name((axis, "AXISNAME")),
+                        node.search_add_child_for_multiple((axis, "AXISNAME")),
                         keys,
                         prev_path=prev_path,
                     )
@@ -515,7 +515,7 @@ def validate_dict_against(
             if best_name is None:
                 return False
 
-            node = node.search_child_with_name(best_name)
+            node = node.search_add_child_for(best_name)
 
         if isinstance(mapping[key], dict) and "link" in mapping[key]:
             # TODO: Follow link and check consistency with current field
@@ -620,7 +620,7 @@ def populate_full_tree(node: NexusNode, max_depth: Optional[int] = 5, depth: int
         # be fixed.
         return
     for child in node.get_all_direct_children_names():
-        child_node = node.search_child_with_name(child)
+        child_node = node.search_add_child_for(child)
         populate_full_tree(child_node, max_depth=max_depth, depth=depth + 1)
 
 


### PR DESCRIPTION
- Adds missing docstrings for `is_a` and `parent_of` relationships
- Fixes a typo and residual code in sibling retrieval
- Renames a function to correctly represent what it does