### PR TITLE
Adds url to automatic definition writing

### DIFF
--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -885,7 +885,7 @@ def write_nexus_def_to_entry(data, entry_name: str, nxdl_def: str):
         overwrite=False,
     )
     update_and_warn(
-        f"/ENTRY[{entry_name}]/definition/@url",
+        f"/ENTRY[{entry_name}]/definition/@URL",
         "https://github.com/FAIRmat-NFDI/nexus_definitions/"
         f"blob/{get_nexus_version_hash()}",
         overwrite=False,

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -25,7 +25,6 @@ from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union
 import h5py
 import lxml.etree as ET
 import numpy as np
-from anytree import Resolver
 
 from pynxtools.dataconverter.helpers import (
     Collector,


### PR DESCRIPTION
This adds that `entry/definition/@url` is automatically set to the nexus definitions repo. We also set this in the root attribute `NexusRepository` but @RonHildebrandt and I thought it would be reasonable to also automatically add it to the definition.

In `NXentry` the attribute is actually uppercase (`@URL`) so we might need to change this accordingly. @RonHildebrandt this should then also be changed in NXraman and any appdefs this is required in.