### PR TITLE
Add raman as plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "pre-commit",
 ]
 convert = [
-    "pynxtools[apm,em,mpes,xps,stm,xrd,ellips]",
+    "pynxtools[apm,em,mpes,xps,stm,xrd,ellips,raman]",
 ]
 mpes = [
     "pynxtools-mpes",
@@ -86,6 +86,9 @@ xrd = [
 ]
 ellips = [
     "pynxtools-ellips",
+]
+raman = [
+    "pynxtools-raman",
 ]
 
 [project.scripts]

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -884,12 +884,6 @@ def write_nexus_def_to_entry(data, entry_name: str, nxdl_def: str):
         get_nexus_version(),
         overwrite=False,
     )
-    update_and_warn(
-        f"/ENTRY[{entry_name}]/definition/@url",
-        "https://github.com/FAIRmat-NFDI/nexus_definitions/"
-        f"blob/{get_nexus_version_hash()}",
-        overwrite=False,
-    )
 
 
 def extract_atom_types(formula, mode="hill"):

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -884,6 +884,12 @@ def write_nexus_def_to_entry(data, entry_name: str, nxdl_def: str):
         get_nexus_version(),
         overwrite=False,
     )
+    update_and_warn(
+        f"/ENTRY[{entry_name}]/definition/@url",
+        "https://github.com/FAIRmat-NFDI/nexus_definitions/"
+        f"blob/{get_nexus_version_hash()}",
+        overwrite=False,
+    )
 
 
 def extract_atom_types(formula, mode="hill"):


### PR DESCRIPTION
This adds the functionalities, that the Raman reader can be used.

The Raman reader is here: https://github.com/FAIRmat-NFDI/pynxtools-raman (currently in stuck in PR, as pynxtools branch with url fix is required solve the CI/CD)

(I dont wanted to commit the changes from the helpers.py file (this should be the URL fix from Florian) - was not intended as I was not aware of that change. How can I remove this here?)