### PR TITLE
Removes unused CLI flags

### DIFF
--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -61,7 +61,6 @@ jobs:
           repository: FAIRmat-NFDI/${{ matrix.plugin }}
           path: ${{ matrix.plugin }}
           ref: ${{ matrix.branch }}
-          lfs: true
       - name: Install nomad
         run: |
           uv pip install --system nomad-lab@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git@pluginise-nexus-code

--- a/src/pynxtools/dataconverter/README.md
+++ b/src/pynxtools/dataconverter/README.md
@@ -37,6 +37,8 @@ Options:
                                   parameters the converter supports.
   --ignore-undocumented           Ignore all undocumented fields during
                                   validation.
+  --fail                          Fail conversion and don't create an output
+                                  file if the validation fails.
   --skip-verify                   Skips the verification routine during
                                   conversion.
   --mapping TEXT                  Takes a <name>.mapping.json file and

--- a/src/pynxtools/dataconverter/README.md
+++ b/src/pynxtools/dataconverter/README.md
@@ -18,7 +18,6 @@ user@box:~$ pip install pynxtools[convert]
 - **generate-template**: This command generates a reader template dictionary for a given NXDL file. It can be called with ```dataconverter generate-template```.
 
 ```console
-user@box:~$ dataconverter --help
 Usage: dataconverter [OPTIONS] COMMAND [ARGS]...
 
 Options:
@@ -27,19 +26,17 @@ Options:
                                   arguments instead. The path to the input
                                   data file to read. (Repeat for more than one
                                   file.)
-  --reader [example|json_map|json_yml]
+  --reader [ellips|em|example|json_map|json_yml|mpes|sts|xps]
                                   The reader to use. default="example"
   --nxdl TEXT                     The name of the NXDL file to use without
                                   extension.This option is required if no '--
                                   params-file' is supplied.
   --output TEXT                   The path to the output NeXus file to be
                                   generated.
-  --fair                          Let the converter know to be stricter in
-                                  checking the documentation.
   --params-file FILENAME          Allows to pass a .yaml file with all the
                                   parameters the converter supports.
-  --undocumented                  Shows a log output for all undocumented
-                                  fields
+  --ignore-undocumented           Ignore all undocumented fields during
+                                  validation.
   --skip-verify                   Skips the verification routine during
                                   conversion.
   --mapping TEXT                  Takes a <name>.mapping.json file and
@@ -52,7 +49,6 @@ Commands:
 Info:
   You can see more options by using --help for specific commands. For example:
   dataconverter generate-template --help
-
 ```
 
 #### Merge partial NeXus files into one

--- a/src/pynxtools/dataconverter/README.md
+++ b/src/pynxtools/dataconverter/README.md
@@ -26,7 +26,7 @@ Options:
                                   arguments instead. The path to the input
                                   data file to read. (Repeat for more than one
                                   file.)
-  --reader [ellips|em|example|json_map|json_yml|mpes|sts|xps]
+  --reader [example|json_map|json_yml]
                                   The reader to use. default="example"
   --nxdl TEXT                     The name of the NXDL file to use without
                                   extension.This option is required if no '--

--- a/src/pynxtools/dataconverter/convert.py
+++ b/src/pynxtools/dataconverter/convert.py
@@ -182,10 +182,7 @@ def convert(
     reader: str,
     nxdl: str,
     output: str,
-    fair: bool = False,
-    undocumented: bool = False,
     skip_verify: bool = False,
-    required: bool = False,
     **kwargs,
 ):
     """The conversion routine that takes the input parameters and calls the necessary functions.
@@ -225,19 +222,6 @@ def convert(
         skip_verify=skip_verify,
         **kwargs,
     )
-
-    if fair and data.undocumented.keys():
-        logger.warning(
-            "There are undocumented paths in the template. This is not acceptable!"
-        )
-        return
-    if undocumented:
-        for path in data.undocumented.keys():
-            if "/@default" in path:
-                continue
-            logger.info(
-                f"NO DOCUMENTATION: The path, {path}, is being written but has no documentation."
-            )
 
     helpers.add_default_root_attributes(data=data, filename=os.path.basename(output))
     Writer(data=data, nxdl_f_path=nxdl_f_path, output_path=output).write()
@@ -310,22 +294,10 @@ def main_cli():
     help="The path to the output NeXus file to be generated.",
 )
 @click.option(
-    "--fair",
-    is_flag=True,
-    default=False,
-    help="Let the converter know to be stricter in checking the documentation.",
-)
-@click.option(
     "--params-file",
     type=click.File("r"),
     default=None,
     help="Allows to pass a .yaml file with all the parameters the converter supports.",
-)
-@click.option(
-    "--undocumented",
-    is_flag=True,
-    default=False,
-    help="Shows a log output for all undocumented fields",
 )
 @click.option(
     "--ignore-undocumented",
@@ -351,10 +323,8 @@ def convert_cli(
     reader: str,
     nxdl: str,
     output: str,
-    fair: bool,
     params_file: str,
     ignore_undocumented: bool,
-    undocumented: bool,
     skip_verify: bool,
     mapping: str,
 ):
@@ -400,8 +370,6 @@ def convert_cli(
             reader,
             nxdl,
             output,
-            fair,
-            undocumented,
             skip_verify,
             ignore_undocumented=ignore_undocumented,
         )


### PR DESCRIPTION
This removes the `--documented` and `--fair` flag from the dataconverter CLI. They are not used in the new validation and create wrong warnings _if_ they are used. They are replaced by the new flag `--ignore-undocumented` for the new validation, which simply ignores all undocumented fields.

cc @rettigl