### PR TITLE
add tests of ellipsometry plugin

### DIFF
--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -20,9 +20,9 @@ jobs:
           # - plugin: pynxtools-apm
           #   branch: main
           #   tests_to_run: tests/.
-          # - plugin: pynxtools-ellips
-          #   branch: main
-          #   tests_to_run: tests/.
+          - plugin: pynxtools-ellips
+            branch: main
+            tests_to_run: tests/.
           # - plugin: pynxtools-em
           #   branch: main
           #   tests_to_run: tests/.


### PR DESCRIPTION
Activating ellipsometry reader tests as the plugin is published.
Idea from @domna 
(lets see if this works out) I just thaught that if this passes cicd, then it everything should be fine?