### PR TITLE
Fix nomad parsing and dataconverter

### DIFF
--- a/src/pynxtools/nomad/dataconverter.py
+++ b/src/pynxtools/nomad/dataconverter.py
@@ -98,7 +98,7 @@ def populate_nexus_subsection(
             data=template, nxdl_f_path=nxdl_f_path, output_path=archive.data.output
         ).write()
         try:
-            from nomad.parsing.nexus.nexus import NexusParser
+            from pynxtools.nomad.parser import NexusParser
 
             nexus_parser = NexusParser()
             nexus_parser.parse(
@@ -133,7 +133,7 @@ def populate_nexus_subsection(
                 data=template, nxdl_f_path=nxdl_f_path, output_path=output_file
             ).write()
 
-            from nomad.parsing.nexus.nexus import NexusParser
+            from pynxtools.nomad.parser import NexusParser
 
             nexus_parser = NexusParser()
             nexus_parser.parse(mainfile=output_file, archive=archive, logger=logger)

--- a/src/pynxtools/nomad/entrypoints.py
+++ b/src/pynxtools/nomad/entrypoints.py
@@ -41,4 +41,5 @@ nexus_parser = NexusParserEntryPoint(
     name="pynxtools parser",
     description="A parser for nexus files.",
     mainfile_name_re=r".*\.nxs",
+    mainfile_mime_re="application/x-hdf5",
 )

--- a/src/pynxtools/nomad/parser.py
+++ b/src/pynxtools/nomad/parser.py
@@ -473,12 +473,9 @@ class NexusParser(MatchingParser):
         self._logger = logger if logger else get_logger(__name__)
         self._clear_class_refs()
 
-        if mainfile.endswith("nxs"):
-            *_, self.nxs_fname = mainfile.rsplit("/", 1)
-            nexus_helper = HandleNexus(logger, mainfile)
-            nexus_helper.process_nexus_master_file(self.__nexus_populate)
-        else:
-            raise ValueError("No Nexus file is found to populate the nexus definition.")
+        *_, self.nxs_fname = mainfile.rsplit("/", 1)
+        nexus_helper = HandleNexus(logger, mainfile)
+        nexus_helper.process_nexus_master_file(self.__nexus_populate)
 
         # TODO: domain experiment could also be registered
         if archive.metadata is None:
@@ -503,13 +500,3 @@ class NexusParser(MatchingParser):
 
         chemical_formulas = self._get_chemical_formulas()
         self.normalize_chemical_formula(chemical_formulas)
-
-    def is_mainfile(
-        self,
-        filename: str,
-        mime: str,
-        buffer: bytes,
-        decoded_buffer: str,
-        compression: str = None,
-    ):
-        return True


### PR DESCRIPTION
This fixes the nomad parsing and some imports in the dataconverter.
The `NexusParser` had a `is_mainfile` function which just returned `True`. This lead to all files being parsed by the `NexusParser`.