### PR TITLE
Add raman plugin to `convert` extra and ci/cd testing

### DIFF
--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -23,6 +23,9 @@ jobs:
           # - plugin: pynxtools-ellips
           #   branch: main
           #   tests_to_run: tests/.
+          - plugin: pynxtools-raman
+            branch: main
+            tests_to_run: tests/.
           # - plugin: pynxtools-em
           #   branch: main
           #   tests_to_run: tests/.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,13 +45,7 @@ identify==2.5.36
 idna==3.7
     # via requests
 importlib-metadata==8.0.0
-    # via
-    #   pynxtools (pyproject.toml)
-    #   markdown
-    #   mkdocs
-    #   mkdocs-get-deps
-importlib-resources==6.4.0
-    # via matplotlib
+    # via pynxtools (pyproject.toml)
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
@@ -177,7 +171,7 @@ requests==2.32.3
     # via mkdocs-material
 ruff==0.4.8
     # via pynxtools (pyproject.toml)
-scipy==1.13.1
+scipy==1.14.0
     # via ase
 six==1.16.0
     # via
@@ -215,6 +209,4 @@ watchdog==4.0.1
 xarray==2024.6.0
     # via pynxtools (pyproject.toml)
 zipp==3.19.2
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,7 +45,13 @@ identify==2.5.36
 idna==3.7
     # via requests
 importlib-metadata==8.0.0
-    # via pynxtools (pyproject.toml)
+    # via
+    #   pynxtools (pyproject.toml)
+    #   markdown
+    #   mkdocs
+    #   mkdocs-get-deps
+importlib-resources==6.4.0
+    # via matplotlib
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
@@ -171,7 +177,7 @@ requests==2.32.3
     # via mkdocs-material
 ruff==0.4.8
     # via pynxtools (pyproject.toml)
-scipy==1.14.0
+scipy==1.13.1
     # via ase
 six==1.16.0
     # via
@@ -209,4 +215,6 @@ watchdog==4.0.1
 xarray==2024.6.0
     # via pynxtools (pyproject.toml)
 zipp==3.19.2
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "pre-commit",
 ]
 convert = [
-    "pynxtools[apm,em,mpes,xps,stm,xrd,ellips]",
+    "pynxtools[apm,em,mpes,xps,stm,xrd,ellips,raman]",
 ]
 mpes = [
     "pynxtools-mpes",
@@ -86,7 +86,9 @@ xrd = [
 ellips = [
     "pynxtools-ellips",
 ]
-
+raman = [
+    "pynxtools-raman",
+]
 [project.entry-points.'nomad.plugin']
 nexus_parser = "pynxtools.nomad.entrypoints:nexus_parser"
 nexus_schema = "pynxtools.nomad.entrypoints:nexus_schema"


### PR DESCRIPTION
As the Raman Reader as plugin is published, this now shall include it in pynxtools with CI/CD.

Updated pyproject.toml, dev-requirements.txt and activated github workflow for CI/CD