### PR TITLE
Allow lists of possible values in config file

### DIFF
--- a/src/pynxtools/dataconverter/readers/multi/reader.py
+++ b/src/pynxtools/dataconverter/readers/multi/reader.py
@@ -17,10 +17,10 @@
 #
 """An example reader implementation for the DataConverter."""
 
+import ast
 import logging
 import os
 import re
-import ast
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from pynxtools.dataconverter.readers.base.reader import BaseReader

--- a/src/pynxtools/dataconverter/readers/multi/reader.py
+++ b/src/pynxtools/dataconverter/readers/multi/reader.py
@@ -157,7 +157,7 @@ def resolve_special_keys(
         new_entry_dict[key] = value
         return
 
-    prefixes: List[Union[Tuple[str, str], str]] = []
+    prefixes: List[Tuple[str, str]] = []
 
     # Regular expression to check if the string contains a list
     if re.match(r"^\[.*\]$", value):

--- a/src/pynxtools/dataconverter/readers/utils.py
+++ b/src/pynxtools/dataconverter/readers/utils.py
@@ -39,7 +39,7 @@ class FlattenSettings:
         convert_dict (dict): Dictionary for renaming keys in the flattend dict.
         replace_nested (dict): Dictionary for renaming nested keys.
         parent_key (str, optional):
-            Parent key of the dictionary. Defaults to "/ENTRY[entry]".
+            Parent key of the dictionary. Defaults to "/ENTRY".
         sep (str, optional): Separator for the keys. Defaults to "/".
     """
 

--- a/src/pynxtools/dataconverter/readers/utils.py
+++ b/src/pynxtools/dataconverter/readers/utils.py
@@ -46,7 +46,7 @@ class FlattenSettings:
     dic: Mapping
     convert_dict: dict
     replace_nested: dict
-    parent_key: str = "/ENTRY[entry]"
+    parent_key: str = "/ENTRY"
     sep: str = "/"
     is_in_section: bool = False
     ignore_keys: Optional[list] = None
@@ -248,8 +248,6 @@ def flatten_json(
                     dont_flatten_link_dict=dont_flatten_link_dict,
                 )
             )
-        elif isinstance(value, str) and value.startswith("@link:"):
-            flattened_config[key] = {"link": value[6:]}
         else:
             flattened_config[key] = value
 


### PR DESCRIPTION
This allows to write `"['@attrs:<text>', '@eln', 'no title']"` in the config file, which gets parse into the prefixes as a list of tuples `[('@attrs', 'text'), ('@eln', ''), ('', 'no title')]`. For each of these, it is checked if a value can be returned (whatever that means for the reader solution) and if so, the value is written. If not, "no title" is written. I think this is much cleaner implementation of having these multiple options than before.

I also changed the `parent_key` in `FlattenSettings` to "/ENTRY" to match our previous discussion. Finally, I removed the link handling in the `flatten_json` as this shall be handled by the link callback. Are there any issues with this?

@domna there were some problems with the handling of `!` for the required fields in optional groups while I was implementing this solution. I think it works now, but I didn't have a good example for this, can you check with your example if it still works?