### PR TITLE
Reraise error on missing file in cli_convert

### DIFF
--- a/src/pynxtools/dataconverter/convert.py
+++ b/src/pynxtools/dataconverter/convert.py
@@ -403,7 +403,7 @@ def convert_cli(
             fail=fail,
         )
     except FileNotFoundError as exc:
-        raise click.BadParameter(exc) from exc
+        raise click.BadParameter(str(exc)) from exc
     except ValidationFailed as exc:
         raise click.ClickException(
             "Validation failed: No file written because '--fail' was requested."

--- a/src/pynxtools/dataconverter/convert.py
+++ b/src/pynxtools/dataconverter/convert.py
@@ -403,9 +403,7 @@ def convert_cli(
             fail=fail,
         )
     except FileNotFoundError as exc:
-        raise click.BadParameter(
-            f"{nxdl} is not a valid application definition", param_hint="--nxdl"
-        ) from exc
+        raise click.BadParameter(exc) from exc
     except ValidationFailed as exc:
         raise click.ClickException(
             "Validation failed: No file written because '--fail' was requested."

--- a/tests/dataconverter/test_convert.py
+++ b/tests/dataconverter/test_convert.py
@@ -88,8 +88,7 @@ def test_find_nxdl(cli_inputs):
     if "NXdoesnotexist" in cli_inputs:
         assert result.exit_code == 2
         assert result.output.endswith(
-            "Error: Invalid value for --nxdl: "
-            "NXdoesnotexist is not a valid application definition\n"
+            "Error: Invalid value: The nxdl file, NXdoesnotexist, was not found.\n"
         )
     else:
         assert isinstance(result.exception, Exception)


### PR DESCRIPTION
Since we already have handlers for missing input, nxdl, and output files, we can simply raise the error again (as `click.BadParameter`) in order to avoid the problem described in #397 