### PR TITLE
To allow entry_type would be written or not.

### DIFF
--- a/src/pynxtools/nomad/dataconverter.py
+++ b/src/pynxtools/nomad/dataconverter.py
@@ -66,6 +66,7 @@ def populate_nexus_subsection(
     output_file_path: Optional[str] = None,
     on_temp_file=False,
     nxs_as_entry=True,
+    write_entry_type=True,
 ):
     """Populate nexus subsection in nomad from nexus template.
 
@@ -84,6 +85,7 @@ def populate_nexus_subsection(
         logger: nomad logger.
         on_temp_file: Whether data will be written in temporary disk, by default False.
         nxs_as_entry: If the nxs file should be as ann nonmad entry or a general file, by default True.
+        write_entry_type: If the attr entry_type in archive.meatadata.entry_type would be written or not.
 
     Raises:
         Exception: could not trigger processing from NexusParser
@@ -107,6 +109,7 @@ def populate_nexus_subsection(
                 mainfile=archive.data.output,
                 archive=archive,
                 logger=logger,
+                write_entry_type=write_entry_type,
             )
             # If a NeXus file written a an entry e.g XRD use case
             if nxs_as_entry:

--- a/src/pynxtools/nomad/dataconverter.py
+++ b/src/pynxtools/nomad/dataconverter.py
@@ -85,7 +85,7 @@ def populate_nexus_subsection(
         logger: nomad logger.
         on_temp_file: Whether data will be written in temporary disk, by default False.
         nxs_as_entry: If the nxs file should be as ann nonmad entry or a general file, by default True.
-        write_entry_type: If the attr entry_type in archive.meatadata.entry_type would be written or not.
+        write_entry_type: If the attr entry_type in archive.meatadata would be written or not.
 
     Raises:
         Exception: could not trigger processing from NexusParser

--- a/src/pynxtools/nomad/parser.py
+++ b/src/pynxtools/nomad/parser.py
@@ -465,6 +465,7 @@ class NexusParser(MatchingParser):
         mainfile: str,
         archive: EntryArchive,
         logger=None,
+        write_entry_type=True,
         child_archives: Dict[str, EntryArchive] = None,
     ) -> None:
         self.archive = archive
@@ -487,7 +488,7 @@ class NexusParser(MatchingParser):
             if getattr(archive.nexus, var, None) is not None:
                 app_def = var
                 break
-        if archive.metadata.entry_type is None:
+        if write_entry_type:
             archive.metadata.entry_type = app_def
             archive.metadata.domain = "nexus"
 


### PR DESCRIPTION
The kwarg `wrte_entry_type` is used in xrd in `nomad_measurement`.

Currently, `populate_nexus_subsection` is being called in a step before running the `normaliser` function of the schema (`ELNXrayDiffraction`). So, the `entry_type` is being written in the `populate_nexus_subsection` and when `nomad` sees the `attr` is filled, `nomad` does not update the value of the `entry_type` which would be `ELNXrayDiffraction`. This is problematic, when the external schema like `ELNXrayDiffraction` uses a `nexus` dataconverter in a internal process.