### PR TITLE
Add notes to How-To to use dev install for verify_nexus

### DIFF
--- a/docs/how-tos/validate-nexus-file.md
+++ b/docs/how-tos/validate-nexus-file.md
@@ -120,6 +120,23 @@ Options:
   --help  Show this message and exit.
 ```
 
+*Development verion installation*
+
+If this installation procedure above does not work, you can use the devlopment installation by using git:
+```
+python -m venv .py39
+source .py39/bin/activate
+git clone https://github.com/FAIRmat-NFDI/pynxtools.git
+cd pynxtools/
+git checkout hdf-based-validation
+git submodule sync –recursive
+git submodule update --init --recursive --jobs=4
+python -m pip install --upgrade pip
+python -m pip install -e .
+python -m pip install -e ".[dev]“
+verify_nexus --help
+```
+
 
 ### Using *verify_nexus*
 

--- a/docs/how-tos/validate-nexus-file.md
+++ b/docs/how-tos/validate-nexus-file.md
@@ -120,9 +120,9 @@ Options:
   --help  Show this message and exit.
 ```
 
-*Development verion installation*
+*Development version installation*
 
-If this installation procedure above does not work, you can use the devlopment installation by using git:
+If this installation procedure above does not work, you can use the development installation by using git:
 ```
 python -m venv .py39
 source .py39/bin/activate


### PR DESCRIPTION
Reason is, the default installation of the branch did not work. The command:

```
pip install git+https://github.com/FAIRmat-NFDI/pynxtools@hdf-based-validation
```
resulted in:
```
WARNING: Built wheel for pynxtools is invalid: Wheel has unexpected file name: expected '0.6.0.post1.dev29+gde56834', got '0.6.0.post1.dev29+gde56834.d20241017'
Failed to build pynxtools
```
It seems somehow, that a different commit version is required.
With the addition of the development install, the user at least can now use this directly (as this will be linked in the Tutorial).

