### PR TITLE
Fix type hints

### DIFF
--- a/src/pynxtools/testing/nexus_conversion.py
+++ b/src/pynxtools/testing/nexus_conversion.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from glob import glob
-from typing import Literal
+from typing import Literal, List, Tuple
 
 try:
     from nomad.client import parse
@@ -150,7 +150,7 @@ class ReaderTest:
         }
         SECTION_SEPARATOR = "DEBUG - ===== "
 
-        def should_skip_line(gen_l: str, ref_l: str, ignore_lines: list[str]) -> bool:
+        def should_skip_line(gen_l: str, ref_l: str, ignore_lines: List[str]) -> bool:
             """Check if both lines start with any ignored prefix."""
             return any(
                 gen_l.startswith(ignore) and ref_l.startswith(ignore)
@@ -159,17 +159,17 @@ class ReaderTest:
 
         def load_logs(
             gen_log_path: str, ref_log_path: str
-        ) -> tuple[list[str], list[str]]:
+        ) -> Tuple[List[str], List[str]]:
             """Load log files and return their contents as lists of lines."""
             with open(gen_log_path, "r", encoding="utf-8") as gen, open(
                 ref_log_path, "r", encoding="utf-8"
             ) as ref:
                 return gen.readlines(), ref.readlines()
 
-        def compare_logs(gen_lines: list[str], ref_lines: list[str]) -> None:
+        def compare_logs(gen_lines: List[str], ref_lines: List[str]) -> None:
             """Compare log lines, ignoring specific differences."""
             if len(gen_lines) != len(ref_lines):
-                assert False, (
+                raise AssertionError(
                     f"Log files are different: mismatched line counts. "
                     f"Generated file has {len(gen_lines)} lines, "
                     f"while reference file has {len(ref_lines)} lines."
@@ -188,11 +188,12 @@ class ReaderTest:
                 if gen_l != ref_l and not should_skip_line(
                     gen_l, ref_l, IGNORE_LINES + section_ignore_lines
                 ):
-                    assert False, (
+                    raise AssertionError(
                         f"Log files are different at line {ind}\n"
                         f"generated: {gen_l}\nreferenced: {ref_l}"
                     )
 
+        # Load log paths
         ref_log_path = get_log_file(self.ref_nexus_file, "ref_nexus.log", self.tmp_path)
         gen_log_path = get_log_file(self.created_nexus, "gen_nexus.log", self.tmp_path)
         gen_lines, ref_lines = load_logs(gen_log_path, ref_log_path)


### PR DESCRIPTION
The previous type hints were only working for `python>3.9` and were breaking the tests on`python>3.8` in the plugins.