### PR TITLE
fix case if the handle function inside get_data is ill defined

### DIFF
--- a/src/pynxtools/dataconverter/readers/multi/reader.py
+++ b/src/pynxtools/dataconverter/readers/multi/reader.py
@@ -421,8 +421,10 @@ class MultiFormatReader(BaseReader):
             if not os.path.exists(file_path):
                 logger.warning(f"File {file_path} does not exist, ignoring entry.")
                 continue
-
-            template.update(self.extensions.get(extension, lambda _: {})(file_path))
+            if self.extensions.get(extension, lambda _: {})(file_path) is None:
+                logger.warning(f"Function for parsing file type with extension '{extension}' not found.")
+            if self.extensions.get(extension, lambda _: {})(file_path) is not None:
+                template.update(self.extensions.get(extension, lambda _: {})(file_path))
 
         template.update(self.setup_template())
         if objects is not None:

--- a/src/pynxtools/dataconverter/readers/multi/reader.py
+++ b/src/pynxtools/dataconverter/readers/multi/reader.py
@@ -422,7 +422,9 @@ class MultiFormatReader(BaseReader):
                 logger.warning(f"File {file_path} does not exist, ignoring entry.")
                 continue
             if self.extensions.get(extension, lambda _: {})(file_path) is None:
-                logger.warning(f"Function for parsing file type with extension '{extension}' not found.")
+                logger.warning(
+                    f"Function for parsing file type with extension '{extension}' not found."
+                )
             if self.extensions.get(extension, lambda _: {})(file_path) is not None:
                 template.update(self.extensions.get(extension, lambda _: {})(file_path))
 


### PR DESCRIPTION
I had the problem that, I renamed a function and forgot it at another position. This was the case, as the name in:

self.extensions = {".yml": self.handle_eln_file}
was different from the defined in the new created MultiformatReader.

Therefore: "self.extensions.get(extension, lambda _: {})(file_path)" was None and then failed in updateing the template. Not sure if this is needed to catch this case (should be avoidable if you know what you do).