### PR TITLE
Allow kwargs in ReaderTest

### DIFF
--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -29,6 +29,7 @@ from _pytest.mark.structures import ParameterSet
 from pynxtools.dataconverter.convert import get_names_of_all_readers, get_reader
 from pynxtools.dataconverter.helpers import generate_template_from_nxdl
 from pynxtools.dataconverter.readers.base.reader import BaseReader
+from pynxtools.dataconverter.readers.multi.reader import MultiFormatReader
 from pynxtools.dataconverter.template import Template
 from pynxtools.dataconverter.validation import validate_dict_against
 
@@ -55,6 +56,15 @@ def get_all_readers() -> List[ParameterSet]:
         readers.append(pytest.param(reader))
 
     return readers
+
+
+@pytest.mark.parametrize("reader", get_all_readers())
+def test_if_readers_are_children_of_base_reader(reader):
+    """Test to verify that all readers are children of BaseReader or MultiFormatReader"""
+    if reader.__name__ != "BaseReader":
+        assert isinstance(reader(), BaseReader) or isinstance(
+            reader(), MultiFormatReader
+        )
 
 
 @pytest.mark.parametrize("reader", get_all_readers())

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -51,30 +51,10 @@ def get_all_readers() -> List[ParameterSet]:
     """Scans through the reader list and returns them for pytest parametrization"""
     readers = []
 
-    # Explicitly removing ApmReader and EmNionReader because we need to add test data
     for reader in [get_reader(x) for x in get_names_of_all_readers()]:
-        if reader.__name__ in (
-            "ApmReader",
-            "EmOmReader",
-            "EmSpctrscpyReader",
-            "EmNionReader",
-        ):
-            readers.append(
-                pytest.param(
-                    reader, marks=pytest.mark.skip(reason="Missing test data.")
-                )
-            )
-        else:
-            readers.append(pytest.param(reader))
+        readers.append(pytest.param(reader))
 
     return readers
-
-
-@pytest.mark.parametrize("reader", get_all_readers())
-def test_if_readers_are_children_of_base_reader(reader):
-    """Test to verify that all readers are children of BaseReader"""
-    if reader.__name__ != "BaseReader":
-        assert isinstance(reader(), BaseReader)
 
 
 @pytest.mark.parametrize("reader", get_all_readers())


### PR DESCRIPTION
This would allows us to pass `config_file=<some-file>` to the `ReaderTest`, which makes it in line with how the readers work in general.