### PR TITLE
Small updates to multi reader

### DIFF
--- a/src/pynxtools/dataconverter/readers/multi/reader.py
+++ b/src/pynxtools/dataconverter/readers/multi/reader.py
@@ -288,7 +288,8 @@ def fill_from_config(
             if "*" in key:
                 dims = callbacks.dims(key, value)
                 dim_data = fill_wildcard_data_indices(config_dict, key, value, dims)
-                for k, v in dim_data.items():
+
+                for k, v in dim_data.copy().items():
                     resolve_special_keys(
                         dim_data,
                         k,

--- a/src/pynxtools/dataconverter/readers/multi/reader.py
+++ b/src/pynxtools/dataconverter/readers/multi/reader.py
@@ -50,7 +50,12 @@ def fill_wildcard_data_indices(config_file_dict, key, value, dims):
     dim_dict = {}
     for dim in dims:
         new_key = key.replace("*", dim)
-        new_val = value.replace("*", dim)
+        if isinstance(value, str):
+            new_val = value.replace("*", dim)
+        elif isinstance(value, list):
+            new_val = [val.replace("*", dim) for val in value]
+        else:
+            new_val = value
 
         if new_key not in config_file_dict and new_val not in get_vals_on_same_level(
             new_key


### PR DESCRIPTION
This solves two problems: 
1) If, in your config file, you have a list with a wildcard like this `"peakPEAK[peak*]/data/@xes":["@attrs:component*/kx, @attrs:component*/ky"]`, all of these values in the list gets replace as for non-list cases.
2) If you have multiple options to resolve a wildcard value like 
`"peakPEAK[peak*]/intensity":"['@attrs:component*/data_cps', '@attrs:component*/data']"`, where the reader first tries to fill from the path `component*/data_cps` and then from `@attrs:component*/data'`, there was an issue with the dict iterator before if the first attempt at filling does not work. This is fixed here.