### PR TITLE
Bug fix for adding attributes to non-existing fields being ignored

### DIFF
--- a/src/pynxtools/dataconverter/convert.py
+++ b/src/pynxtools/dataconverter/convert.py
@@ -176,11 +176,16 @@ def transfer_data_into_template(
     for entry_name in entry_names:
         helpers.write_nexus_def_to_entry(data, entry_name, nxdl_name)
     if not skip_verify:
-        valid = validate_dict_against(
+        [valid, keys_to_remove] = validate_dict_against(
             nxdl_name,
             data,
             ignore_undocumented=ignore_undocumented,
         )
+
+        # remove attributes that belong to non-existing fields
+
+        for key in keys_to_remove:
+            data.__delitem__(key)
 
         if fail and not valid:
             raise ValidationFailed(

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -563,8 +563,8 @@ def validate_dict_against(
         keys_to_remove = []
 
         for key in mapping:
-            last_index=key.rfind("/")
-            if key[last_index+1] == "@":
+            last_index = key.rfind("/")
+            if key[last_index + 1] == "@":
                 # key is an attribute. Find a corresponding parent, check all the other children of this parent
                 attribute_parent_checked = False
                 # True if found the value (so, the parent is a field) or non-attribute children (so the parent is a group)
@@ -574,14 +574,16 @@ def validate_dict_against(
                             # the parent is a field
                             attribute_parent_checked = True
                             break
-                        elif key_iterating[last_index+1] != "@":
+                        elif key_iterating[last_index + 1] != "@":
                             # the parent is a group
                             attribute_parent_checked = True
                             break
                 if not attribute_parent_checked:
                     keys_to_remove.append(key)
                     collector.collect_and_log(
-                        key[0:last_index], ValidationProblem.AttributeForNonExistingField, None
+                        key[0:last_index],
+                        ValidationProblem.AttributeForNonExistingField,
+                        None,
                     )
         return keys_to_remove
 

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -631,7 +631,7 @@ def validate_dict_against(
             )
 
     keys_to_remove = check_attributes_of_nonexisting_field()
-    return [not collector.has_validation_problems(), keys_to_remove]
+    return (not collector.has_validation_problems(), keys_to_remove)
 
 
 def populate_full_tree(node: NexusNode, max_depth: Optional[int] = 5, depth: int = 0):

--- a/src/pynxtools/testing/nexus_conversion.py
+++ b/src/pynxtools/testing/nexus_conversion.py
@@ -141,7 +141,7 @@ class ReaderTest:
         with self.caplog.at_level(caplog_level):
             _ = validate_dict_against(
                 self.nxdl, read_data, ignore_undocumented=ignore_undocumented
-            )
+            )[0]
         assert self.caplog.text == ""
 
         add_default_root_attributes(

--- a/tests/dataconverter/test_helpers.py
+++ b/tests/dataconverter/test_helpers.py
@@ -536,7 +536,7 @@ def test_validate_data_dict(caplog, data_dict, error_message, request):
         "required-field-provided-in-variadic-optional-group",
     ):
         with caplog.at_level(logging.WARNING):
-            assert validate_dict_against("NXtest", data_dict)
+            assert validate_dict_against("NXtest", data_dict)[0]
         assert caplog.text == ""
     # Missing required fields caught by logger with warning
     elif request.node.callspec.id in (
@@ -548,11 +548,11 @@ def test_validate_data_dict(caplog, data_dict, error_message, request):
     ):
         assert "" == caplog.text
         captured_logs = caplog.records
-        assert not validate_dict_against("NXtest", data_dict)
+        assert not validate_dict_against("NXtest", data_dict)[0]
         assert any(error_message in rec.message for rec in captured_logs)
     else:
         with caplog.at_level(logging.WARNING):
-            assert not validate_dict_against("NXtest", data_dict)
+            assert not validate_dict_against("NXtest", data_dict)[0]
 
         assert error_message in caplog.text
 

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -117,6 +117,6 @@ def test_has_correct_read_func(reader, caplog):
                 with caplog.at_level(logging.WARNING):
                     validate_dict_against(
                         supported_nxdl, read_data, ignore_undocumented=True
-                    )
+                    )[0]
 
                 print(caplog.text)

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -98,7 +98,7 @@ def alter_dict(new_values: Dict[str, Any], data_dict: Dict[str, Any]) -> Dict[st
 )
 def test_valid_data_dict(caplog, data_dict):
     with caplog.at_level(logging.WARNING):
-        validate_dict_against("NXtest", data_dict)
+        validate_dict_against("NXtest", data_dict)[0]
     assert caplog.text == ""
 
 
@@ -116,6 +116,6 @@ def test_valid_data_dict(caplog, data_dict):
 )
 def test_validation_shows_warning(caplog, data_dict, error_message):
     with caplog.at_level(logging.WARNING):
-        assert not validate_dict_against("NXtest", data_dict)
+        assert not validate_dict_against("NXtest", data_dict)[0]
 
     assert error_message in caplog.text


### PR DESCRIPTION
Fix for the problem that resulted in the issue #394 

If input .h5 file for dataconverter had attributes for a missing field, the validation ignored the issue and writer created a group instead of the field and tried to attach the attributes. Now validation checks for such attributes, returns warning, and such attributes are deleted from the data sent to writer.