### PR TITLE
remove mean from stats fields, and fix naming

### DIFF
--- a/src/pynxtools/nomad/parser.py
+++ b/src/pynxtools/nomad/parser.py
@@ -327,12 +327,11 @@ class NexusParser(MatchingParser):
                     instancename = get_quantity_base_name(data_instance_name)
                     for suffix, stat in zip(
                         [
-                            "__mean",
                             "__var",
                             "__min",
                             "__max",
                             "__size",
-                            "__dim",
+                            "__ndim",
                         ],
                         field_stats[1:],
                     ):

--- a/src/pynxtools/nomad/schema.py
+++ b/src/pynxtools/nomad/schema.py
@@ -544,14 +544,13 @@ def __add_quantity_stats(container: Section, quantity: Quantity):
     basename = get_quantity_base_name(quantity.name)
     for suffix, dtype in zip(
         [
-            "__mean",
             "__var",
             "__min",
             "__max",
             "__size",
             "__ndim",
         ],
-        [np.float64, np.float64, None, None, np.int32, np.int32],
+        [np.float64, np.float64, np.float64, np.int32, np.int32],
     ):
         container.quantities.append(
             Quantity(


### PR DESCRIPTION
Previously, the values and names where not matched correctly, I believe this fixes it. I removed mean, as this is set to the __field value anyways.