### PR TITLE
Fix memory leak in nexus parser

### DIFF
--- a/src/pynxtools/nexus/nexus.py
+++ b/src/pynxtools/nexus/nexus.py
@@ -846,6 +846,8 @@ class HandleNexus:
             # To test if hdf_file is open print(self.in_file.id.valid)
             self.in_file.close()
             # To test if hdf_file is open print(self.in_file.id.valid)
+            # clear lru_cache to avoid memory pileup
+            get_inherited_hdf_nodes.cache_clear()
 
 
 @click.command()


### PR DESCRIPTION
clear lru_cache after each parsing

closes #548 