### PR TITLE
Do not log `read_nexus` to the console in tests

### DIFF
--- a/src/pynxtools/testing/nexus_conversion.py
+++ b/src/pynxtools/testing/nexus_conversion.py
@@ -208,6 +208,8 @@ class ReaderTest:
 
             section_ignore_lines = []
             section = None
+
+            diffs = []
             for ind, (gen_l, ref_l) in enumerate(zip(gen_lines, ref_lines)):
                 if gen_l.startswith(SECTION_SEPARATOR) and ref_l.startswith(
                     SECTION_SEPARATOR
@@ -219,10 +221,13 @@ class ReaderTest:
                 if gen_l != ref_l and not should_skip_line(
                     gen_l, ref_l, IGNORE_LINES + section_ignore_lines
                 ):
-                    raise AssertionError(
-                        f"Log files are different at line {ind}\n"
-                        f"generated: {gen_l}\nreferenced: {ref_l}"
-                    )
+                    diffs += [
+                        f"Log files are different at line {ind}\ngenerated: {gen_l}\nreferenced: {ref_l}"
+                    ]
+
+            if diffs:
+                diff_report = "\n".join(diffs)
+                raise AssertionError(diff_report)
 
         # Load log paths
         ref_log_path = get_log_file(self.ref_nexus_file, "ref_nexus.log", self.tmp_path)

--- a/tests/nexus/test_nexus.py
+++ b/tests/nexus/test_nexus.py
@@ -167,6 +167,14 @@ def test_nexus(tmp_path):
     example_data = os.path.join(
         os.getcwd(), "src", "pynxtools", "data", "201805_WSe2_arpes.nxs"
     )
+
+    root_logger = logging.getLogger()
+
+    for logger_instance in (root_logger, logger):
+        if logger_instance.hasHandlers():
+            for handler in logger_instance.handlers[:]:
+                logger_instance.removeHandler(handler)
+
     logger.setLevel(logging.DEBUG)
     handler = logging.FileHandler(os.path.join(tmp_path, "nexus_test.log"), "w")
     formatter = logging.Formatter("%(levelname)s - %(message)s")


### PR DESCRIPTION
Printing the whole log only unnecessarily fills up the test log without helping too much. To still see the line-by-line difference, I am now using `difflib`.