### PR TITLE
Update NeXus search app in pynxtools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ nexus_parser = "pynxtools.nomad.entrypoints:nexus_parser"
 nexus_schema = "pynxtools.nomad.entrypoints:nexus_schema"
 nexus_data_converter = "pynxtools.nomad.entrypoints:nexus_data_converter"
 nexus_app = "pynxtools.nomad.entrypoints:nexus_app"
-nxsensor_scan_app = "pynxtools.nomad.entrypoints:nxsensor_scan_app"
 iv_temp_example = "pynxtools.nomad.entrypoints:iv_temp_example"
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ nexus_parser = "pynxtools.nomad.entrypoints:nexus_parser"
 nexus_schema = "pynxtools.nomad.entrypoints:nexus_schema"
 nexus_data_converter = "pynxtools.nomad.entrypoints:nexus_data_converter"
 nexus_app = "pynxtools.nomad.entrypoints:nexus_app"
+nxsensor_scan_app = "pynxtools.nomad.entrypoints:nxsensor_scan_app"
 iv_temp_example = "pynxtools.nomad.entrypoints:iv_temp_example"
 
 [project.scripts]

--- a/src/pynxtools/nomad/entrypoints.py
+++ b/src/pynxtools/nomad/entrypoints.py
@@ -71,37 +71,29 @@ from nomad.config.models.ui import (
     Column,
     Menu,
     MenuItemHistogram,
-    MenuItemOption,
     MenuItemPeriodicTable,
     MenuItemTerms,
+    MenuSizeEnum,
     SearchQuantities,
 )
 
 schema = "pynxtools.nomad.schema.Root"
 
-nxdefs_inheriting_from_sensorscan = [
-    "NXsensor_scan",
-    "NXiv_temp",
-    "NXspm",
-    "NXsts",
-    "NXafm",
-    "NXstm",
-]
 
-nxsensor_scan_app = AppEntryPoint(
-    name="NXsensor_scan App",
-    description="App for NXsensor_scan and inheriting from it classes.",
+nexus_app = AppEntryPoint(
+    name="NeXus App",
+    description="Simple Generic NeXus app.",
     app=App(
         # Label of the App
-        label="Simple Scan",
+        label="NeXus",
         # Path used in the URL, must be unique
-        path="nxsensor_scan",
+        path="nexusapp",
         # Used to categorize apps in the explore menu
         category="Experiment",
         # Brief description used in the app menu
-        description="Search simple scan experiments (NXsensor_scan and inheriting classes), including output of NOMAD CAMELS",
+        description="A simple search app customized for generic NeXus data.",
         # Longer description that can also use markdown
-        readme="This page allows to search for generic experimental entries corresponding to NXsensor_scan and inheriting from it classes, including output of NOMAD CAMELS. It is similar to the entries search, but with reduced filter set, modified menu on the left and different shown columns. The dashboard directly shows useful interactive statistics about the data",
+        readme="This page allows to search for generic NeXus Experiment Entries. It is similar to the entries search, but with reduced filter set, modified menu on the left and different shown columns. The dashboard directly shows useful interactive statistics about the data",
         # If you want to use quantities from a custom schema, you need to load
         # the search quantities from it first here. Note that you can use a glob
         # syntax to load the entire package, or just a single schema from a
@@ -147,25 +139,19 @@ nxsensor_scan_app = AppEntryPoint(
                 search_quantity=f"data.ENTRY[*].definition__field#{schema}",
                 selected=True,
             ),
-            Column(
-                title="Protocol",
-                search_quantity=f"data.ENTRY[*].NOTE[?name=='protocol'].file_name__field#{schema}#str",
-                selected=False,
-            ),
         ],
         # Dictionary of search filters that are always enabled for queries made
         # within this app. This is especially important to narrow down the
         # results to the wanted subset.
-        filters_locked={
-            f"data.ENTRY.definition__field#{schema}": nxdefs_inheriting_from_sensorscan,
-        },
-        # filters_locked={"section_defs.definition_qualified_name": [schema]},
+        filters_locked={"section_defs.definition_qualified_name": [schema]},
         # Controls the menu shown on the left
         menu=Menu(
+            size=MenuSizeEnum.MD,
             title="Menu",
             items=[
                 Menu(
                     title="Elements",
+                    size=MenuSizeEnum.XXL,
                     items=[
                         MenuItemPeriodicTable(
                             search_quantity="results.material.elements",
@@ -180,13 +166,42 @@ nxsensor_scan_app = AppEntryPoint(
                             width=6,
                             options=0,
                         ),
+                        MenuItemTerms(
+                            search_quantity="results.material.chemical_formula_reduced",
+                            width=6,
+                            options=0,
+                        ),
+                        MenuItemTerms(
+                            search_quantity="results.material.chemical_formula_anonymous",
+                            width=6,
+                            options=0,
+                        ),
                         MenuItemHistogram(
                             x="results.material.n_elements",
                         ),
                     ],
                 ),
                 Menu(
+                    title="Experiment type",
+                    size=MenuSizeEnum.LG,
+                    items=[
+                        MenuItemTerms(
+                            title="Entry Type",
+                            search_quantity=f"entry_type",
+                            width=12,
+                            options=12,
+                        ),
+                        MenuItemTerms(
+                            title="NeXus Class",
+                            search_quantity=f"data.ENTRY.definition__field#{schema}",
+                            width=12,
+                            options=12,
+                        ),
+                    ],
+                ),
+                Menu(
                     title="Instruments",
+                    size=MenuSizeEnum.LG,
                     items=[
                         MenuItemTerms(
                             title="Model",
@@ -204,6 +219,7 @@ nxsensor_scan_app = AppEntryPoint(
                 ),
                 Menu(
                     title="Samples",
+                    size=MenuSizeEnum.LG,
                     items=[
                         MenuItemTerms(
                             title="Name",
@@ -220,222 +236,96 @@ nxsensor_scan_app = AppEntryPoint(
                     ],
                 ),
                 Menu(
-                    title="Authors",
+                    title="Authors / Origin",
+                    size=MenuSizeEnum.LG,
                     items=[
                         MenuItemTerms(
-                            title="Name",
+                            title="Entry Author",
                             search_quantity=f"data.ENTRY.USER.name__field#{schema}",
                             width=12,
-                            options=12,
+                            options=5,
+                        ),
+                        MenuItemTerms(
+                            title="User ID / Entry Author",
+                            search_quantity=f"data.ENTRY.userID.name__field#{schema}#str",
+                            width=12,
+                            options=5,
+                        ),
+                        MenuItemTerms(
+                            title="Upload Author",
+                            search_quantity=f"authors.name",
+                            width=12,
+                            options=5,
                         ),
                         MenuItemTerms(
                             title="Affiliation",
                             search_quantity=f"data.ENTRY.USER.affiliation__field#{schema}",
                             width=12,
-                            options=12,
+                            options=5,
                         ),
                     ],
                 ),
-                Menu(
-                    title="Protocols (NOMAD CAMELS)",
-                    items=[
-                        MenuItemTerms(
-                            title="CAMELS files",
-                            search_quantity=f"data.ENTRY.PROCESS.program__field#{schema}",
-                            width=12,
-                            options={
-                                "NOMAD CAMELS": MenuItemOption(
-                                    label="NOMAD CAMELS entries only",
-                                ),
-                            },
-                            show_header=False,
-                            show_input=False,
-                        ),
-                        MenuItemTerms(
-                            title="Protocols (only for CAMELS files)",
-                            search_quantity=f"data.ENTRY.NOTE.file_name__field#{schema}#str",
-                            width=12,
-                            options=12,
-                        ),
-                    ],
+                MenuItemHistogram(
+                    title="Start Time",
+                    x=f"data.ENTRY.start_time#{schema}",
+                    autorange=True,
+                ),
+                MenuItemHistogram(
+                    title="Upload Creation Time",
+                    x=f"upload_create_time",
+                    autorange=True,
                 ),
             ],
         ),
         # Controls the default dashboard shown in the search interface
         dashboard={
             "widgets": [
-                {
-                    "type": "histogram",
-                    "show_input": False,
-                    "autorange": True,
-                    "nbins": 30,
-                    "scale": "linear",
-                    "quantity": f"data.ENTRY.start_time#{schema}",
-                    "title": "Start Time",
-                    "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 6, "w": 10, "y": 0, "x": 0}
-                    },
-                },
-                {
-                    "type": "terms",
-                    "show_input": False,
-                    "scale": "linear",
-                    "quantity": f"entry_type",
-                    "title": "Entry Type",
-                    "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 6, "w": 5, "y": 6, "x": 0}
-                    },
-                },
-                {
-                    "type": "terms",
-                    "show_input": False,
-                    "scale": "linear",
-                    "quantity": f"data.ENTRY.SAMPLE.sample_id__field#{schema}",
-                    "title": "Sample ID",
-                    "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 12, "w": 4, "y": 0, "x": 14}
-                    },
-                },
-                {
-                    "type": "terms",
-                    "show_input": False,
-                    "scale": "linear",
-                    "quantity": f"data.ENTRY.USER.name__field#{schema}",
-                    "title": "Author",
-                    "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 6, "w": 5, "y": 6, "x": 5}
-                    },
-                },
-                {
-                    "type": "terms",
-                    "show_input": False,
-                    "scale": "linear",
-                    "quantity": f"data.ENTRY.SAMPLE.name__field#{schema}",
-                    "title": "Sample",
-                    "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 12, "w": 4, "y": 0, "x": 10}
-                    },
-                },
-            ]
-        },
-    ),
-)
-
-nexus_app = AppEntryPoint(
-    name="NexusApp",
-    description="Simple Generic NeXus app.",
-    app=App(
-        # Label of the App
-        label="NeXus",
-        # Path used in the URL, must be unique
-        path="nexusapp",
-        # Used to categorize apps in the explore menu
-        category="Experiment",
-        # Brief description used in the app menu
-        description="A simple search app customized for generic NeXus data.",
-        # Longer description that can also use markdown
-        readme="This is a simple App to support basic search for NeXus based Experiment Entries.",
-        # If you want to use quantities from a custom schema, you need to load
-        # the search quantities from it first here. Note that you can use a glob
-        # syntax to load the entire package, or just a single schema from a
-        # package.
-        search_quantities=SearchQuantities(
-            include=[f"*#{schema}"],
-        ),
-        # Controls which columns are shown in the results table
-        columns=[
-            Column(quantity="entry_id", selected=True),
-            Column(quantity=f"entry_type", selected=True),
-            Column(
-                title="definition",
-                quantity=f"data.ENTRY[*].definition__field#{schema}",
-                selected=True,
-            ),
-            Column(
-                title="start_time",
-                quantity=f"data.ENTRY[*].start_time__field#{schema}",
-                selected=True,
-            ),
-            Column(
-                title="title",
-                quantity=f"data.ENTRY[*].title__field#{schema}",
-                selected=True,
-            ),
-        ],
-        # Dictionary of search filters that are always enabled for queries made
-        # within this app. This is especially important to narrow down the
-        # results to the wanted subset. Any available search filter can be
-        # targeted here. This example makes sure that only entries that use
-        # MySchema are included.
-        filters_locked={"section_defs.definition_qualified_name": [schema]},
-        # Controls the menu shown on the left
-        menu=Menu(
-            title="Material",
-            items=[
-                Menu(
-                    title="elements",
-                    items=[
-                        MenuItemPeriodicTable(
-                            quantity="results.material.elements",
-                        ),
-                        MenuItemTerms(
-                            quantity="results.material.chemical_formula_hill",
-                            width=6,
-                            options=0,
-                        ),
-                        MenuItemTerms(
-                            quantity="results.material.chemical_formula_iupac",
-                            width=6,
-                            options=0,
-                        ),
-                        MenuItemHistogram(
-                            x="results.material.n_elements",
-                        ),
-                    ],
-                )
-            ],
-        ),
-        # Controls the default dashboard shown in the search interface
-        dashboard={
-            "widgets": [
-                {
-                    "type": "histogram",
-                    "show_input": False,
-                    "autorange": True,
-                    "nbins": 30,
-                    "scale": "linear",
-                    "quantity": f"data.ENTRY.start_time__field#{schema}",
-                    "title": "Start Time",
-                    "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 4, "w": 12, "y": 0, "x": 0}
-                    },
-                },
-                {
-                    "type": "terms",
-                    "show_input": False,
-                    "scale": "linear",
-                    "quantity": f"entry_type",
-                    "title": "Entry Type",
-                    "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 8, "w": 4, "y": 0, "x": 12}
-                    },
-                },
-                {
-                    "type": "terms",
-                    "show_input": False,
-                    "scale": "linear",
-                    "quantity": f"data.ENTRY.definition__field#{schema}",
-                    "title": "Definition",
-                    "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 8, "w": 4, "y": 0, "x": 16}
-                    },
-                },
                 {
                     "type": "periodic_table",
                     "scale": "linear",
                     "quantity": f"results.material.elements",
                     "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 4, "w": 12, "y": 4, "x": 0}
+                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 10, "y": 0, "x": 0}
+                    },
+                },
+                {
+                    "type": "terms",
+                    "show_input": True,
+                    "scale": "linear",
+                    "quantity": f"entry_type",
+                    "title": "Entry Type",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 10}
+                    },
+                },
+                {
+                    "type": "terms",
+                    "show_input": True,
+                    "scale": "linear",
+                    "quantity": f"data.ENTRY.definition__field#{schema}",
+                    "title": "NeXus Class",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 14}
+                    },
+                },
+                {
+                    "type": "terms",
+                    "show_input": True,
+                    "scale": "linear",
+                    "quantity": f"data.ENTRY.USER.name__field#{schema}",
+                    "title": "Author",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 18}
+                    },
+                },
+                {
+                    "type": "terms",
+                    "show_input": True,
+                    "scale": "linear",
+                    "quantity": f"data.ENTRY.SAMPLE.name__field#{schema}",
+                    "title": "Sample",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 22}
                     },
                 },
             ]

--- a/src/pynxtools/nomad/entrypoints.py
+++ b/src/pynxtools/nomad/entrypoints.py
@@ -285,7 +285,11 @@ nexus_app = AppEntryPoint(
                     "scale": "linear",
                     "quantity": f"results.material.elements",
                     "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 10, "y": 0, "x": 0}
+                        "sm": {"minH": 3, "minW": 3, "h": 5, "w": 8, "y": 0, "x": 0},
+                        "md": {"minH": 3, "minW": 3, "h": 7, "w": 12, "y": 0, "x": 0},
+                        "lg": {"minH": 3, "minW": 3, "h": 10, "w": 14, "y": 0, "x": 0},
+                        "xl": {"minH": 3, "minW": 3, "h": 7, "w": 10, "y": 0, "x": 0},
+                        "xxl": {"minH": 3, "minW": 3, "h": 7, "w": 10, "y": 0, "x": 0},
                     },
                 },
                 {
@@ -295,7 +299,11 @@ nexus_app = AppEntryPoint(
                     "quantity": f"entry_type",
                     "title": "Entry Type",
                     "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 10}
+                        "sm": {"minH": 3, "minW": 3, "h": 5, "w": 4, "y": 0, "x": 8},
+                        "md": {"minH": 3, "minW": 3, "h": 7, "w": 6, "y": 0, "x": 12},
+                        "lg": {"minH": 3, "minW": 3, "h": 5, "w": 5, "y": 0, "x": 14},
+                        "xl": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 10},
+                        "xxl": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 10},
                     },
                 },
                 {
@@ -305,7 +313,11 @@ nexus_app = AppEntryPoint(
                     "quantity": f"data.ENTRY.definition__field#{schema}",
                     "title": "NeXus Class",
                     "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 14}
+                        "sm": {"minH": 3, "minW": 3, "h": 5, "w": 4, "y": 5, "x": 0},
+                        "md": {"minH": 3, "minW": 3, "h": 7, "w": 6, "y": 7, "x": 0},
+                        "lg": {"minH": 3, "minW": 3, "h": 5, "w": 5, "y": 0, "x": 19},
+                        "xl": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 14},
+                        "xxl": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 14},
                     },
                 },
                 {
@@ -315,7 +327,11 @@ nexus_app = AppEntryPoint(
                     "quantity": f"data.ENTRY.USER.name__field#{schema}",
                     "title": "Author",
                     "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 18}
+                        "sm": {"minH": 3, "minW": 3, "h": 5, "w": 4, "y": 5, "x": 4},
+                        "md": {"minH": 3, "minW": 3, "h": 7, "w": 6, "y": 7, "x": 6},
+                        "lg": {"minH": 3, "minW": 3, "h": 5, "w": 5, "y": 5, "x": 14},
+                        "xl": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 18},
+                        "xxl": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 18},
                     },
                 },
                 {
@@ -325,7 +341,11 @@ nexus_app = AppEntryPoint(
                     "quantity": f"data.ENTRY.SAMPLE.name__field#{schema}",
                     "title": "Sample",
                     "layout": {
-                        "lg": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 22}
+                        "sm": {"minH": 3, "minW": 3, "h": 5, "w": 4, "y": 5, "x": 8},
+                        "md": {"minH": 3, "minW": 3, "h": 7, "w": 6, "y": 7, "x": 12},
+                        "lg": {"minH": 3, "minW": 3, "h": 5, "w": 5, "y": 5, "x": 19},
+                        "xl": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 22},
+                        "xxl": {"minH": 3, "minW": 3, "h": 7, "w": 4, "y": 0, "x": 22},
                     },
                 },
             ]

--- a/src/pynxtools/nomad/entrypoints.py
+++ b/src/pynxtools/nomad/entrypoints.py
@@ -71,12 +71,254 @@ from nomad.config.models.ui import (
     Column,
     Menu,
     MenuItemHistogram,
+    MenuItemOption,
     MenuItemPeriodicTable,
     MenuItemTerms,
     SearchQuantities,
 )
 
 schema = "pynxtools.nomad.schema.Root"
+
+nxdefs_inheriting_from_sensorscan = [
+    "NXsensor_scan",
+    "NXiv_temp",
+    "NXspm",
+    "NXsts",
+    "NXafm",
+    "NXstm",
+]
+
+nxsensor_scan_app = AppEntryPoint(
+    name="NXsensor_scan App",
+    description="App for NXsensor_scan and inheriting from it classes.",
+    app=App(
+        # Label of the App
+        label="Simple Scan",
+        # Path used in the URL, must be unique
+        path="nxsensor_scan",
+        # Used to categorize apps in the explore menu
+        category="Experiment",
+        # Brief description used in the app menu
+        description="Search simple scan experiments (NXsensor_scan and inheriting classes), including output of NOMAD CAMELS",
+        # Longer description that can also use markdown
+        readme="This page allows to search for generic experimental entries corresponding to NXsensor_scan and inheriting from it classes, including output of NOMAD CAMELS. It is similar to the entries search, but with reduced filter set, modified menu on the left and different shown columns. The dashboard directly shows useful interactive statistics about the data",
+        # If you want to use quantities from a custom schema, you need to load
+        # the search quantities from it first here. Note that you can use a glob
+        # syntax to load the entire package, or just a single schema from a
+        # package.
+        search_quantities=SearchQuantities(
+            include=[f"*#{schema}"],
+        ),
+        # Controls which columns are shown in the results table
+        columns=[
+            Column(title="Entry ID", search_quantity="entry_id", selected=True),
+            Column(
+                title="File Name",
+                search_quantity=f"data.name#{schema}",
+                selected=True,
+            ),
+            Column(
+                title="Start Time",
+                search_quantity=f"data.ENTRY[*].start_time#{schema}",
+                selected=True,
+            ),
+            Column(
+                title="Description",
+                search_quantity=f"data.ENTRY[*].experiment_description__field#{schema}",
+                selected=True,
+            ),
+            Column(
+                title="Author",
+                search_quantity=f"[data.ENTRY[*].USER[*].name__field, data.ENTRY[*].userID[*].name__field]#{schema}",
+                selected=True,
+            ),
+            Column(
+                title="Sample",
+                search_quantity=f"data.ENTRY[*].SAMPLE[*].name__field#{schema}",
+                selected=True,
+            ),
+            Column(
+                title="Sample ID",
+                search_quantity=f"data.ENTRY[*].SAMPLE[*].sample_id__field#{schema}",
+                selected=False,
+            ),
+            Column(
+                title="Definition",
+                search_quantity=f"data.ENTRY[*].definition__field#{schema}",
+                selected=True,
+            ),
+            Column(
+                title="Protocol",
+                search_quantity=f"data.ENTRY[*].NOTE[?name=='protocol'].file_name__field#{schema}#str",
+                selected=False,
+            ),
+        ],
+        # Dictionary of search filters that are always enabled for queries made
+        # within this app. This is especially important to narrow down the
+        # results to the wanted subset.
+        filters_locked={
+            f"data.ENTRY.definition__field#{schema}": nxdefs_inheriting_from_sensorscan,
+        },
+        # Controls the menu shown on the left
+        menu=Menu(
+            title="Menu",
+            items=[
+                Menu(
+                    title="Elements",
+                    items=[
+                        MenuItemPeriodicTable(
+                            search_quantity="results.material.elements",
+                        ),
+                        MenuItemTerms(
+                            search_quantity="results.material.chemical_formula_hill",
+                            width=6,
+                            options=0,
+                        ),
+                        MenuItemTerms(
+                            search_quantity="results.material.chemical_formula_iupac",
+                            width=6,
+                            options=0,
+                        ),
+                        MenuItemHistogram(
+                            x="results.material.n_elements",
+                        ),
+                    ],
+                ),
+                Menu(
+                    title="Instruments",
+                    items=[
+                        MenuItemTerms(
+                            title="Model",
+                            search_quantity=f"data.ENTRY.INSTRUMENT.name__field#{schema}",
+                            width=12,
+                            options=12,
+                        ),
+                        MenuItemTerms(
+                            name="Name",
+                            search_quantity=f"data.ENTRY.INSTRUMENT.name#{schema}",
+                            width=12,
+                            options=12,
+                        ),
+                    ],
+                ),
+                Menu(
+                    title="Samples",
+                    items=[
+                        MenuItemTerms(
+                            title="Name",
+                            search_quantity=f"data.ENTRY.SAMPLE.name__field#{schema}",
+                            width=12,
+                            options=12,
+                        ),
+                        MenuItemTerms(
+                            title="Sample ID",
+                            search_quantity=f"data.ENTRY.SAMPLE.sample_id__field#{schema}",
+                            width=12,
+                            options=12,
+                        ),
+                    ],
+                ),
+                Menu(
+                    title="Authors",
+                    items=[
+                        MenuItemTerms(
+                            title="Name",
+                            search_quantity=f"data.ENTRY.USER.name__field#{schema}",
+                            width=12,
+                            options=12,
+                        ),
+                        MenuItemTerms(
+                            title="Affiliation",
+                            search_quantity=f"data.ENTRY.USER.affiliation__field#{schema}",
+                            width=12,
+                            options=12,
+                        ),
+                    ],
+                ),
+                Menu(
+                    title="Protocols (NOMAD CAMELS)",
+                    items=[
+                        MenuItemTerms(
+                            title="CAMELS files",
+                            search_quantity=f"data.ENTRY.PROCESS.program__field#{schema}",
+                            width=12,
+                            options={
+                                "NOMAD CAMELS": MenuItemOption(
+                                    label="NOMAD CAMELS entries only",
+                                ),
+                            },
+                            show_header=False,
+                            show_input=False,
+                        ),
+                        MenuItemTerms(
+                            title="Protocols (only for CAMELS files)",
+                            search_quantity=f"data.ENTRY.NOTE.file_name__field#{schema}#str",
+                            width=12,
+                            options=12,
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        # Controls the default dashboard shown in the search interface
+        dashboard={
+            "widgets": [
+                {
+                    "type": "histogram",
+                    "show_input": False,
+                    "autorange": True,
+                    "nbins": 30,
+                    "scale": "linear",
+                    "quantity": f"data.ENTRY.start_time#{schema}",
+                    "title": "Start Time",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 6, "w": 10, "y": 0, "x": 0}
+                    },
+                },
+                {
+                    "type": "terms",
+                    "show_input": False,
+                    "scale": "linear",
+                    "quantity": f"entry_type",
+                    "title": "Entry Type",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 6, "w": 5, "y": 6, "x": 0}
+                    },
+                },
+                {
+                    "type": "terms",
+                    "show_input": False,
+                    "scale": "linear",
+                    "quantity": f"data.ENTRY.SAMPLE.sample_id__field#{schema}",
+                    "title": "Sample ID",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 12, "w": 4, "y": 0, "x": 14}
+                    },
+                },
+                {
+                    "type": "terms",
+                    "show_input": False,
+                    "scale": "linear",
+                    "quantity": f"data.ENTRY.USER.name__field#{schema}",
+                    "title": "Author",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 6, "w": 5, "y": 6, "x": 5}
+                    },
+                },
+                {
+                    "type": "terms",
+                    "show_input": False,
+                    "scale": "linear",
+                    "quantity": f"data.ENTRY.SAMPLE.name__field#{schema}",
+                    "title": "Sample",
+                    "layout": {
+                        "lg": {"minH": 3, "minW": 3, "h": 12, "w": 4, "y": 0, "x": 10}
+                    },
+                },
+            ]
+        },
+    ),
+)
 
 nexus_app = AppEntryPoint(
     name="NexusApp",

--- a/src/pynxtools/nomad/entrypoints.py
+++ b/src/pynxtools/nomad/entrypoints.py
@@ -114,7 +114,7 @@ nxsensor_scan_app = AppEntryPoint(
             Column(title="Entry ID", search_quantity="entry_id", selected=True),
             Column(
                 title="File Name",
-                search_quantity=f"data.name#{schema}",
+                search_quantity=f"mainfile",
                 selected=True,
             ),
             Column(
@@ -159,6 +159,7 @@ nxsensor_scan_app = AppEntryPoint(
         filters_locked={
             f"data.ENTRY.definition__field#{schema}": nxdefs_inheriting_from_sensorscan,
         },
+        # filters_locked={"section_defs.definition_qualified_name": [schema]},
         # Controls the menu shown on the left
         menu=Menu(
             title="Menu",


### PR DESCRIPTION
A generic app for search/statistics visualization for NXsensor_scan and inheriting classes (currently NXiv_temp, NXspm, NXstm, NXafm, NXsts); also will work for NOMAD CAMELS entries (most likely, version>=1.8.0).
Please let me know if:
- NXspm/sts/stm/afm etc should be removed from the filter, as they have a dedicated app with more suitable options
- NOMAD CAMELS should be mentioned more/less/not at all (currently only menu/protocols(NOMAD CAMELS and protocol column, which is not shown by default) have filters that work only for them)
- Any functionality / descriptions shall be added or improved
- Any way to replace explicit list of classes inheriting from NXsensor_scan with something more automated exists

For tests, files from corresponding example uploads will work. Test CAMELS files can be found here: https://box.hu-berlin.de/d/2812ff0b8104478ba160/   (just put any of them in an upload without any extra files/schemas)