### PR TITLE
update CI/CD workflows

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -3,10 +3,7 @@ name: build_and_deploy_mkdocs
 on:
   push:
     branches:
-      - master  # Triggers deployment on push to the main branch
-
-env:
-  UV_SYSTEM_PYTHON: true
+      - master  # Triggers deployment on push to the master branch
 
 permissions:
    contents: write
@@ -27,10 +24,10 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version to 3.11
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.x'
+          python-version: 3.11
 
       - name: Cache mkdocs-material environment
         uses: actions/cache@v3
@@ -42,7 +39,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
           uv pip install --no-cache-dir ".[docs]"
 
       - name: Build and Deploy

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -12,6 +12,9 @@ on:
     #   - 'pyproject.toml'
     #   - 'dev-requirements.txt'
 
+env:
+  python-version: 3.11
+
 jobs:
   validate_dependencies:
     runs-on: ubuntu-latest
@@ -29,16 +32,16 @@ jobs:
       working-directory: ./nomad
       run: |
         echo "pynxtools[convert]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref || github.ref_name }}" >> test_plugins.txt
-    - name: Install uv and set the python version to 3.11
+    - name: Install uv and set the python version to ${{ env.python-version }}
       uses: astral-sh/setup-uv@v5
       with:
-        python-version: 3.11
+        python-version: ${{ env.python-version }}
     - name: Generate (dev-)requirements.txt from modified pyproject.toml
       working-directory: ./nomad
       run: |
-        uv pip compile --universal -p 3.11 --annotation-style=line --extra=infrastructure --extra=parsing --output-file=requirements.txt pyproject.toml
-        uv pip compile --universal -p 3.11 --annotation-style=line --extra=dev --extra=infrastructure --extra=parsing --output-file=requirements-dev.txt requirements.txt pyproject.toml
-        uv pip compile --universal -p 3.11 --annotation-style=line --output-file=requirements-plugins.txt --unsafe-package nomad-lab -c requirements-dev.txt test_plugins.txt
+        uv pip compile --universal -p ${{ env.python-version }} --annotation-style=line --extra=infrastructure --extra=parsing --output-file=requirements.txt pyproject.toml
+        uv pip compile --universal -p ${{ env.python-version }} --annotation-style=line --extra=dev --extra=infrastructure --extra=parsing --output-file=requirements-dev.txt requirements.txt pyproject.toml
+        uv pip compile --universal -p ${{ env.python-version }} --annotation-style=line --output-file=requirements-plugins.txt --unsafe-package nomad-lab -c requirements-dev.txt test_plugins.txt
     - name: Install NOMAD dependencies with pynxtools from current branch
       working-directory: ./nomad
       run: |

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Add pynxtools dependency in NOMAD test_plugins.txt
       working-directory: ./nomad
       run: |
+        echo "" >> test_plugins.txt
         echo "pynxtools[convert]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref || github.ref_name }}" >> test_plugins.txt
     - name: Install uv and set the python version to ${{ env.python-version }}
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/nomad-requirements.yml
+++ b/.github/workflows/nomad-requirements.yml
@@ -12,9 +12,6 @@ on:
     #   - 'pyproject.toml'
     #   - 'dev-requirements.txt'
 
-env:
-  UV_SYSTEM_PYTHON: true
-
 jobs:
   validate_dependencies:
     runs-on: ubuntu-latest
@@ -28,26 +25,20 @@ jobs:
         git clone --depth 1 --branch develop --recurse-submodules https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
         git submodule update --init --recursive --depth 1
 
-    - name: Replace pynxtools dependency in NOMAD pyproject.toml
+    - name: Add pynxtools dependency in NOMAD test_plugins.txt
       working-directory: ./nomad
       run: |
-        sed -i 's|pynxtools\[convert\]==[0-9]\+\(\.[0-9]\+\)\+\([0-9]\)|pynxtools\[convert\]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref || github.ref_name }} |' default_plugins.txt
-    - name: Set up Python
-      uses: actions/setup-python@v5
+        echo "pynxtools[convert]@git+https://github.com/FAIRmat-NFDI/pynxtools.git@${{ github.head_ref || github.ref_name }}" >> test_plugins.txt
+    - name: Install uv and set the python version to 3.11
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: '3.11'
-
-    - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-
+        python-version: 3.11
     - name: Generate (dev-)requirements.txt from modified pyproject.toml
       working-directory: ./nomad
       run: |
         uv pip compile --universal -p 3.11 --annotation-style=line --extra=infrastructure --extra=parsing --output-file=requirements.txt pyproject.toml
         uv pip compile --universal -p 3.11 --annotation-style=line --extra=dev --extra=infrastructure --extra=parsing --output-file=requirements-dev.txt requirements.txt pyproject.toml
-        uv pip compile --universal -p 3.11 --annotation-style=line --output-file=requirements-plugins.txt --unsafe-package nomad-lab -c requirements-dev.txt default_plugins.txt
-
+        uv pip compile --universal -p 3.11 --annotation-style=line --output-file=requirements-plugins.txt --unsafe-package nomad-lab -c requirements-dev.txt test_plugins.txt
     - name: Install NOMAD dependencies with pynxtools from current branch
       working-directory: ./nomad
       run: |

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches: [master]
 
-env:
-  UV_SYSTEM_PYTHON: true
-
 jobs:
   pytest:
     name: pytest (${{ matrix.plugin }})
@@ -49,18 +46,17 @@ jobs:
             tests_to_run: tests/.
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version to 3.12
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Install dependencies
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv pip install --system coverage coveralls
+          uv pip install coverage coveralls
       - name: Install package
         run: |
           uv pip install ".[dev]"

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  python-version: 3.11
+
 jobs:
   pytest:
     name: pytest (${{ matrix.plugin }})
@@ -50,10 +53,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Install uv and set the python version to 3.12
+      - name: Install uv and set the python version to ${{ env.python-version }}
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: 3.12
+          python-version: ${{ env.python-version }}
       - name: Install dependencies
         run: |
           uv pip install coverage coveralls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  python-version: 3.11
+
 jobs:
   deploy:
     name: Upload release to PyPI
@@ -18,10 +21,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: recursive
-    - name: Install uv and set the python version to 3.11
+    - name: Install uv and set the python version to ${{ env.python-version }}
       uses: astral-sh/setup-uv@v5
       with:
-        python-version: 3.11
+        python-version: ${{ env.python-version }}
     - name: Install dependencies
       run: |
         uv pip install build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  UV_SYSTEM_PYTHON: true
-
 jobs:
   deploy:
     name: Upload release to PyPI
@@ -21,13 +18,12 @@ jobs:
       with:
         fetch-depth: 0
         submodules: recursive
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Install uv and set the python version to 3.11
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: "3.x"
+        python-version: 3.11
     - name: Install dependencies
       run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
         uv pip install build
     - name: Git tag version
       id: git_tag_version

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,12 +18,9 @@ jobs:
         run: |
           git submodule sync --recursive
           git submodule update --init --recursive --jobs=4
-      - name: Install package
+      - name: Install package and dev requirements
         run: |
-          uv pip install --no-deps .
-      - name: Install dev requirements
-        run: |
-          uv pip install -r dev-requirements.txt
+          uv pip install .[dev]
       - name: ruff check
         run: |
           ruff check src/pynxtools tests

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,15 +2,18 @@ name: linting
 
 on: [push]
 
+env:
+  python-version: 3.11
+
 jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv and set the python version to 3.11
+      - name: Install uv and set the python version to ${{ env.python-version }}
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.python-version }}
       - name: Install dependencies
         run: |
           git submodule sync --recursive

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,23 +2,19 @@ name: linting
 
 on: [push]
 
-env:
-  UV_SYSTEM_PYTHON: true
-
 jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version to 3.11
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.10"
+          python-version: 3.11
       - name: Install dependencies
         run: |
           git submodule sync --recursive
           git submodule update --init --recursive --jobs=4
-          curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install package
         run: |
           uv pip install --no-deps .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,28 +9,32 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  UV_SYSTEM_PYTHON: true
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Install uv and set the python version to ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+      - name: Set up Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python_version }}
       - name: Install dependencies
         run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
           uv pip install coverage coveralls
       - name: Install nomad
-        if: "${{ matrix.python-version != '3.8' && matrix.python-version != '3.9'}}"
+        if: "${{ matrix.python_version != '3.8' && matrix.python_version != '3.9'}}"
         run: |
           uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
       - name: Install pynx

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,32 +9,28 @@ on:
   pull_request:
     branches: [master]
 
-env:
-  UV_SYSTEM_PYTHON: true
-
 jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version to ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
           uv pip install coverage coveralls
       - name: Install nomad
-        if: "${{ matrix.python_version != '3.8' && matrix.python_version != '3.9'}}"
+        if: "${{ matrix.python-version != '3.8' && matrix.python-version != '3.9'}}"
         run: |
           uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
       - name: Install pynx


### PR DESCRIPTION
NOMAD replaced `default_plugins.txt` by `test_plugins.txt` in https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/2383 and removed `pynxtools[convert]` from there. Therefore, we needed to change the `nomad-requirements` workflow. 

Some more updates in the other workflows:
- Use `setup-uv` action everywhere
- Use python 3.11 consistently -> shall we use 3.12 at some point?