### PR TITLE
convert array enums to list before checking

### DIFF
--- a/src/pynxtools/nomad/parser.py
+++ b/src/pynxtools/nomad/parser.py
@@ -225,7 +225,10 @@ class NexusParser(MatchingParser):
                         attribute = attr_value
                         # TODO: get unit from attribute <xxx>_units
                         if isinstance(metainfo_def.type, MEnum):
-                            attribute = str(attr_value)
+                            if isinstance(attr_value, np.ndarray):
+                                attribute = str(attr_value.tolist())
+                            else:
+                                attribute = str(attr_value)
                         elif not isinstance(attr_value, str):
                             if isinstance(attr_value, np.ndarray):
                                 attr_list = attr_value.tolist()


### PR DESCRIPTION
This fixes a bug in the checking of enums in the nexusparser. If enum elements are defined as lists, e.g. here: https://github.com/FAIRmat-NFDI/nexus_definitions/blob/ecbe9b27a9aeefaf562470ec688297228d10e839/contributed_definitions/NXmpes_arpes.nxdl.xml#L151

the parser converted the array into a string rather than the list, which missed the commas to separate list items. This PR fixes that.

Previous Error/Warning:

`string"Traceback (most recent call last): File "/home/femtolab_admin/nomad/nomad-distro-dev/packages/pynxtools/src/pynxtools/nomad/parser.py", line 247, in _populate_data current.m_set(metainfo_def, attribute) File "/home/femtolab_admin/nomad/nomad-distro-dev/packages/nomad-FAIR/nomad/metainfo/metainfo.py", line 1251, in m_set return definition.__set__(self, value, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/femtolab_admin/nomad/nomad-distro-dev/packages/nomad-FAIR/nomad/metainfo/metainfo.py", line 719, in wrapper return method(self, obj, value, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/femtolab_admin/nomad/nomad-distro-dev/packages/nomad-FAIR/nomad/metainfo/metainfo.py", line 3319, in __set__ m_quantity.value = self.type.normalize( ^^^^^^^^^^^^^^^^^^^^ File "/home/femtolab_admin/nomad/nomad-distro-dev/packages/nomad-FAIR/nomad/metainfo/data_type.py", line 787, in normalize return self._normalize_impl(value, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/femtolab_admin/nomad/nomad-distro-dev/packages/nomad-FAIR/nomad/metainfo/data_type.py", line 1072, in _normalize_impl return self._validate_value(value) ^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/femtolab_admin/nomad/nomad-distro-dev/packages/nomad-FAIR/nomad/metainfo/data_type.py", line 1057, in _validate_value raise ValueError(f'{value} is not a value of this enumeration.') ValueError: [1 0 0] is not a value of this enumeration."`