### PR TITLE
Testing for generating template from NeXusTree

### DIFF
--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -29,24 +29,23 @@ It also allows for adding further nodes from the inheritance chain on the fly.
 """
 
 from functools import lru_cache, reduce
-from typing import Any, List, Dict, Literal, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
 import lxml.etree as ET
 from anytree.node.nodemixin import NodeMixin
 
-from pynxtools import get_definitions_url
+from pynxtools import NX_DOC_BASES, get_definitions_url
 from pynxtools.dataconverter.helpers import (
     get_all_parents_for,
     get_nxdl_root_and_path,
-    is_variadic,
     is_appdef,
+    is_variadic,
     remove_namespace_from_tag,
 )
 from pynxtools.definitions.dev_tools.utils.nxdl_utils import (
     get_nx_namefit,
     is_name_type,
 )
-from pynxtools import NX_DOC_BASES
 
 NexusType = Literal[
     "NX_BINARY",

--- a/src/pynxtools/debug.py
+++ b/src/pynxtools/debug.py
@@ -1,0 +1,59 @@
+from pynxtools.dataconverter.helpers import generate_template_from_nxdl
+from pynxtools.dataconverter.nexus_tree import *
+from pynxtools.dataconverter.template import Template
+
+spm_appdef = "NXspm"
+spmT = generate_tree_from(spm_appdef)
+
+
+def add_template_key_from(nx_node,
+                       parent_path = ""):
+    key = None
+    unit = None
+    if nx_node.type == "attribute":
+        leaf_part = (f"{nx_node.name}[{nx_node.name}]"
+                     if nx_node.variadic else nx_node.name)
+        key = f"{parent_path}/@{leaf_part}"
+    elif nx_node.type == "field":
+        leaf_part = (f"{nx_node.name}[{nx_node.name}]"
+                     if nx_node.variadic else nx_node.name)
+        key = f"{parent_path}/{leaf_part}"
+        if hasattr(nx_node, "unit") and nx_node.unit:
+            unit = f"{key}/@units"
+    elif nx_node.type == "group":
+        leaf_part = f"{nx_node.name}[{nx_node.name}]"
+        key = f"{parent_path}/{leaf_part}"
+    if key:
+        template[nx_node.optionality][key] = None
+    if unit:
+        template[nx_node.optionality][unit] = None
+    return key
+def build_template_from_nexus_tree(appdef_root, template, parent_path = ""):
+    """
+    Build a template from the nexus tree.
+    """
+    for child in appdef_root.children:
+        key = add_template_key_from(child, parent_path)
+        if not key:
+            continue
+        build_template_from_nexus_tree(child, template, key)
+template = Template()
+build_template_from_nexus_tree(spmT, template)
+template_old = Template()
+
+root, _ = get_nxdl_root_and_path(spm_appdef)
+generate_template_from_nxdl(
+    root=root,
+    template=template_old,
+)
+print(' #### check optional missing keys')
+template_ = template
+template_old_ = template_old
+def check_missing():
+    for key, _ in template_['optional'].items():
+        if key not in template_old_['optional']:
+            print(f"OPTIONAL Missing key in template_old: {key}")
+    print(' #### check required missing keys')
+    for key, _ in template_['required'].items():
+        if key not in template_old_['required']:
+            print(f"REQUIRED: Missing key in template_old: {key}")


### PR DESCRIPTION
In the current implementation how the Template instance is populated, not all the inheritance fields can be resolved specially some fields from inheritance chain are missing. Taking leverage from NeXus tree would be a good option for that.
 
Beside that, the template only stores the path of the nexus concept path as a plain string. And in the reader plugin, the reader developer somehow needs to check the proper type of the data, and most of the time, the information of the data type or unit type for a field or attribute is noted in reader plugin manually. Which is error prone and needs extra effort. This PR is intended to handle.

- [ ] Generate the template from NeXus tree
- [ ] Each template key should be an object that would carry other information such as `data type`, `unit type`, `nameType` info which will be carry exact information as an nxdl node contains. This method would justify `nxdl` as a single source of truth. 
- [ ] Add the features of template to curate the data fields and attributes according to the nxdl.
- [ ] Do not alter the current interface of the Template but implement the feature(2 & 3) as an extension of the current feature.
