### PR TITLE
Goup tests that use the same resources.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,7 +39,7 @@ jobs:
           uv pip install -e ".[dev]"
       - name: Test with pytest
         run: |
-          coverage run -m pytest -sv --show-capture=no tests
+          coverage run -m pytest -sv --show-capture=no tests -n auto --dist loadgroup
       - name: Submit to coveralls
         continue-on-error: true
         if: "${{ matrix.python-version == '3.12'}}"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,7 +39,7 @@ jobs:
           uv pip install -e ".[dev]"
       - name: Test with pytest
         run: |
-          coverage run -m pytest -sv --show-capture=no tests -n auto --dist loadgroup
+          coverage run -m pytest -sv --show-capture=no tests
       - name: Submit to coveralls
         continue-on-error: true
         if: "${{ matrix.python-version == '3.12'}}"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -36,6 +36,8 @@ cycler==0.12.1
     # via matplotlib
 distlib==0.3.9
     # via virtualenv
+execnet==2.1.1
+    # via pytest-xdist
 filelock==3.18.0
     # via virtualenv
 flexcache==0.3
@@ -163,9 +165,12 @@ pytest==8.3.5
     #   pynxtools (pyproject.toml)
     #   pytest-cov
     #   pytest-timeout
+    #   pytest-xdist
 pytest-cov==6.1.1
     # via pynxtools (pyproject.toml)
 pytest-timeout==2.3.1
+    # via pynxtools (pyproject.toml)
+pytest-xdist==3.6.1
     # via pynxtools (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/docs/how-tos/run-tests-in-parallel.md
+++ b/docs/how-tos/run-tests-in-parallel.md
@@ -1,5 +1,27 @@
-# Run `pynxtools` Tests in Parallel
-Pytest test framework also allows tests to run in parallel with some other third party pytest plugin, e.g. `pytest-xdist`. In our pytest for pynxtools we are using `[pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/)` to execute the test in prallel. In case of sheared resources among multiple test, the tests are being grouped by fixtures by `pytest.mark.xdist_group` to prevent any classic race coditions.
+# Running `pynxtools` Tests in Parallel
 
+The `pytest` framework allows tests to run in sequential and parallel using third-party plugins such as [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/stable/). In our `pytest` setup for `pynxtools`, we use `pytest-xdist` to execute tests in parallel. To handle shared resources among multiple tests tests are grouped using the `@pytest.mark.xdist_group` fixture. This prevents classic race conditions by ensuring that tests sharing the same resources are executed serially.
 
+## Running Tests Sequentially
 
+In a local setup, tests can be run sequentially using the following command:
+
+```console
+$ python -m pytest tests
+```
+
+This will execute all tests in a sequential manner. For more details, refer to the official documentation: [How to invoke pytest](https://docs.pytest.org/en/stable/how-to/usage.html).
+
+## Running Tests in Parallel
+
+The `pytest-xdist` plugin can be used to speed up test execution by distributing tests among available workers. To prevent race conditions, tests that share the same resources are grouped using the `@pytest.mark.xdist_group(name="group_name")` fixture. These grouped tests must be run with the `--dist loadgroup` flag. For example:
+
+```console
+$ python -m pytest tests -n auto --dist loadgroup
+```
+
+Here:
+- The `-n auto` flag tells `pytest` to automatically distribute tests among all available workers.
+- The `--dist loadgroup` flag ensures that tests marked with the same @pytest.mark.xdist_group(name="...") are executed serially.
+
+This setup allows for efficient parallel test execution while maintaining the integrity of tests that depend on shared resources.

--- a/docs/how-tos/run-tests-in-parallel.md
+++ b/docs/how-tos/run-tests-in-parallel.md
@@ -1,6 +1,6 @@
 # Running `pynxtools` Tests in Parallel
 
-The `pytest` framework allows tests to run in sequential and parallel using third-party plugins such as [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/stable/). In our `pytest` setup for `pynxtools`, we use `pytest-xdist` to execute tests in parallel. To handle shared resources among multiple tests tests are grouped using the `@pytest.mark.xdist_group` fixture. This prevents classic race conditions by ensuring that tests sharing the same resources are executed serially.
+The `pytest` framework allows tests to run in sequential and parallel using third-party plugins such as [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/stable/). In our `pytest` setup for `pynxtools`, we use `pytest-xdist` to execute tests in parallel. To handle shared resources among multiple tests, tests are grouped using the `@pytest.mark.xdist_group` fixture. This prevents classic race conditions by ensuring that tests sharing the same resources are executed sequentially.
 
 ## Running Tests Sequentially
 

--- a/docs/how-tos/run-tests-in-parallel.md
+++ b/docs/how-tos/run-tests-in-parallel.md
@@ -1,0 +1,5 @@
+# Run `pynxtools` Tests in Parallel
+Pytest test framework also allows tests to run in parallel with some other third party pytest plugin, e.g. `pytest-xdist`. In our pytest for pynxtools we are using `[pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/)` to execute the test in prallel. In case of sheared resources among multiple test, the tests are being grouped by fixtures by `pytest.mark.xdist_group` to prevent any classic race coditions.
+
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ How-to guides provide step-by-step instructions for a wide range of tasks.
 - [Validation of NeXus files](how-tos/validate-nexus-file.md)
 - [Creation of NeXus files in python via hard-coding](how-tos/create-nexus-files-by-python.md)
 - [Using pynxtools test framework for plugins](how-tos/using-pynxtools-test-framework.md)
+- [Using pynxtools tests in parallel](how-tos/run-tests-in-parallel.md)
 
 __The following How-to guides are still under development:__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pytest",
     "pytest-timeout",
     "pytest-cov",
+    "pytest-xdist",
     "structlog",
     "types-pyyaml",
     "types-pytz",

--- a/tests/dataconverter/test_convert.py
+++ b/tests/dataconverter/test_convert.py
@@ -131,6 +131,7 @@ def test_cli(caplog, cli_inputs):
     elif result.exit_code == 2:
         assert "Error: Missing option '--nxdl'" in result.output
 
+
 @pytest.mark.xdist_group(name="shared_resource")
 def test_links_and_virtual_datasets(tmp_path):
     """A test for the convert CLI to check whether a Dataset object is created,
@@ -196,6 +197,7 @@ def test_links_and_virtual_datasets(tmp_path):
         )
 
     restore_xarray_file_from_tmp(tmp_path)
+
 
 @pytest.mark.xdist_group(name="shared_resource")
 def test_compression(tmp_path):

--- a/tests/dataconverter/test_convert.py
+++ b/tests/dataconverter/test_convert.py
@@ -226,6 +226,7 @@ def test_compression(tmp_path):
 
     restore_xarray_file_from_tmp(tmp_path)
 
+
 @pytest.mark.xdist_group(name="shared_resource")
 def test_params_file():
     """Check if the parameters file is read correctly."""

--- a/tests/dataconverter/test_convert.py
+++ b/tests/dataconverter/test_convert.py
@@ -22,9 +22,10 @@ import shutil
 from pathlib import Path
 
 import h5py
-import pynxtools.dataconverter.convert as dataconverter
 import pytest
 from click.testing import CliRunner
+
+import pynxtools.dataconverter.convert as dataconverter
 from pynxtools.dataconverter.readers.base.reader import BaseReader
 
 
@@ -225,7 +226,7 @@ def test_compression(tmp_path):
 
     restore_xarray_file_from_tmp(tmp_path)
 
-
+@pytest.mark.xdist_group(name="shared_resource")
 def test_params_file():
     """Check if the parameters file is read correctly."""
     dirpath = Path(__file__).parent.parent / "data" / "dataconverter"

--- a/tests/dataconverter/test_convert.py
+++ b/tests/dataconverter/test_convert.py
@@ -131,7 +131,7 @@ def test_cli(caplog, cli_inputs):
     elif result.exit_code == 2:
         assert "Error: Missing option '--nxdl'" in result.output
 
-
+@pytest.mark.xdist_group(name="shared_resource")
 def test_links_and_virtual_datasets(tmp_path):
     """A test for the convert CLI to check whether a Dataset object is created,
 
@@ -197,7 +197,7 @@ def test_links_and_virtual_datasets(tmp_path):
 
     restore_xarray_file_from_tmp(tmp_path)
 
-
+@pytest.mark.xdist_group(name="shared_resource")
 def test_compression(tmp_path):
     """A test for the convert CLI to check whether a Dataset object is compressed."""
 

--- a/tests/dataconverter/test_convert.py
+++ b/tests/dataconverter/test_convert.py
@@ -133,6 +133,7 @@ def test_cli(caplog, cli_inputs):
         assert "Error: Missing option '--nxdl'" in result.output
 
 
+# Shared resources: xarray_saved_small_calibration.h5 and testdata.json
 @pytest.mark.xdist_group(name="shared_resource")
 def test_links_and_virtual_datasets(tmp_path):
     """A test for the convert CLI to check whether a Dataset object is created,
@@ -200,10 +201,10 @@ def test_links_and_virtual_datasets(tmp_path):
     restore_xarray_file_from_tmp(tmp_path)
 
 
+# Shared resources: xarray_saved_small_calibration.h5 and testdata.json
 @pytest.mark.xdist_group(name="shared_resource")
 def test_compression(tmp_path):
     """A test for the convert CLI to check whether a Dataset object is compressed."""
-
     dirpath = os.path.join(
         os.path.dirname(__file__), "../data/dataconverter/readers/example"
     )
@@ -227,6 +228,7 @@ def test_compression(tmp_path):
     restore_xarray_file_from_tmp(tmp_path)
 
 
+# Shared resources: xarray_saved_small_calibration.h5 and testdata.json
 @pytest.mark.xdist_group(name="shared_resource")
 def test_params_file():
     """Check if the parameters file is read correctly."""

--- a/tests/nexus/test_nexus.py
+++ b/tests/nexus/test_nexus.py
@@ -19,7 +19,6 @@
 
 import logging
 import os
-import difflib
 
 import lxml.etree as ET
 import numpy as np
@@ -160,6 +159,7 @@ def test_get_nexus_classes_units_attributes():
     assert "NX_FLOAT" in nexus_attribute_list
 
 
+@pytest.mark.xdist_group(name="shared_file_201805_WSe2_arpes")
 def test_nexus(tmp_path):
     """
     The nexus test function

--- a/tests/nomad/test_parsing.py
+++ b/tests/nomad/test_parsing.py
@@ -36,6 +36,7 @@ from pynxtools.nomad.schema import nexus_metainfo_package
 from pynxtools.nomad.utils import _rename_nx_for_nomad as rename_nx_for_nomad
 
 
+@pytest.mark.xdist_group(name="shared_file_201805_WSe2_arpes")
 def test_nexus_example():
     archive = EntryArchive()
 


### PR DESCRIPTION
**Problem:** Both tests `test_convert::test_compression and test_convert::test_links_and_virtual_fields` are writing the same file `xarray_saved_small_calibration.h5` from different tests. So, if the tests are run in parallel, two workers fall into a race condition.

This PR serializes the tests `test_convert::test_compression` and `test_convert::test_links_and_virtual_fields` using the grouping feature `xdist-group` from `pytest-xdist`.

In parallel testing, this feature allows scheduling tests over the workers but keeps the grouped test under the same worker, which resolves the classic race condition.

To use this feature, we need to tell pytest to run the grouped test under the same worker using `--dist loadgroup` flag, e.g. 

`$: python -m pytest -n auto --dist loadgroup`.

This resolves the issue [PR 575: Tests race condition](https://github.com/FAIRmat-NFDI/pynxtools/issues/575)  

- [ ] Update documentation on how to run tests in parallel conditions.