### PR TITLE
allow inheritance for non-enumerated fields from other enumerated fields

### DIFF
--- a/src/pynxtools/dataconverter/nexus_tree.py
+++ b/src/pynxtools/dataconverter/nexus_tree.py
@@ -905,7 +905,7 @@ class NexusEntity(NexusNode):
             if elem_enum is not None:
                 if self.items is None:
                     # Case where inherited entity is enumerated, but current node isn't
-                    return False
+                    return True
                 elem_enum_open = elem_enum.attrib.get("open", "false")
 
                 if elem_enum_open == "true":


### PR DESCRIPTION
Previously, fields that don't define enumerations did not inherit from fields that have an enumeration. But in the appdef design, the idea was that you can skip the enumeration because you _don't_ want to specialize it. Hence, we should also such kind of inheritance by default.

As an example [`/NXmpes/ENTRY/INSTRUMENT/ELECTRONANALYZER/COLLECTIONCOLUMN/projection-field`](https://fairmat-nfdi.github.io/nexus_definitions/classes/contributed_definitions/NXmpes.html#nxmpes-entry-instrument-electronanalyzer-collectioncolumn-projection-field) was not inheriting from [`/NXcollectioncolumn/projection-field`](https://fairmat-nfdi.github.io/nexus_definitions/classes/contributed_definitions/NXcollectioncolumn.html#nxcollectioncolumn-projection-field) in the NexusTree implementation.