### PR TITLE
convert int-like values silently into float-like for NX_FLOAT

### DIFF
--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -672,6 +672,10 @@ def convert_int_to_float(value):
         return float(value)
     elif isinstance(value, list):
         return [convert_int_to_float(v) for v in value]
+    elif isinstance(value, tuple):
+        return tuple(convert_int_to_float(v) for v in value)
+    elif isinstance(value, set):
+        return {convert_int_to_float(v) for v in value}
     elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer):
         return value.astype(float)
     else:

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -658,6 +658,26 @@ def convert_str_to_bool_safe(value: str) -> Optional[bool]:
     raise ValueError(f"Could not interpret string '{value}' as boolean.")
 
 
+def convert_int_to_float(value):
+    """
+    Converts int-like values to float, including values in arrays, and lists
+
+    Args:
+        value: The input value, which can be a single value, list, or numpy array.
+
+    Returns:
+        The input value with all int-like values converted to float.
+    """
+    if isinstance(value, int):
+        return float(value)
+    elif isinstance(value, list):
+        return [convert_int_to_float(v) for v in value]
+    elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer):
+        return value.astype(float)
+    else:
+        return value
+
+
 def is_valid_data_field(
     value: Any, nxdl_type: str, nxdl_enum: list, nxdl_enum_open: bool, path: str
 ) -> Any:
@@ -680,6 +700,12 @@ def is_valid_data_field(
             try:
                 value = convert_str_to_bool_safe(value)
             except (ValueError, TypeError):
+                collector.collect_and_log(
+                    path, ValidationProblem.InvalidType, accepted_types, nxdl_type
+                )
+        elif accepted_types[0] is float:
+            value = convert_int_to_float(value)
+            if not is_valid_data_type(value, accepted_types):
                 collector.collect_and_log(
                     path, ValidationProblem.InvalidType, accepted_types, nxdl_type
                 )

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -362,10 +362,19 @@ TEMPLATE["required"][
                 "/ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value",
                 0,
             ),
+            [],
+            id="int-instead-of-float",
+        ),
+        pytest.param(
+            alter_dict(
+                TEMPLATE,
+                "/ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value",
+                np.complex128(0),
+            ),
             [
                 "The value at /ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value should be one of the following Python types: (<class 'float'>, <class 'numpy.floating'>), as defined in the NXDL as NX_FLOAT."
             ],
-            id="int-instead-of-float",
+            id="complex-instead-of-float",
         ),
         pytest.param(
             alter_dict(
@@ -534,12 +543,17 @@ TEMPLATE["required"][
                 "/ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value",
                 [2],  # pylint: disable=E1126
             ),
-            [
-                "The value at /ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value should be "
-                "one of the following Python types: (<class 'float'>, <class 'numpy.floating'>), as defined in the NXDL "
-                "as NX_FLOAT."
-            ],
+            [],
             id="list-of-int-instead-of-float",
+        ),
+        pytest.param(
+            alter_dict(
+                TEMPLATE,
+                "/ENTRY[my_entry]/NXODD_name[nxodd_name]/float_value",
+                np.array([2]),  # pylint: disable=E1126
+            ),
+            [],
+            id="array-of-int-instead-of-float",
         ),
         pytest.param(
             set_to_none_in_dict(


### PR DESCRIPTION
As discussed with @lukaspie, I believe we should not be strict with NX_FLOAT and convert int-like values into float-like values silently. I don't see any case where this would cause an issue, but if NX_FLOAT values are encoded as ints in some source file, it can be difficult to change this in the writing process. One example is the example E1 from pynxtools_mpes https://github.com/FAIRmat-NFDI/pynxtools-mpes/blob/60aa3d5724f7a1578287cb1331008a47c95c91ae/src/pynxtools_mpes/nomad/examples/E1%20Convert%20to%20NeXus.ipynb where one NX_FLOAT value is encoded as int in the hdf5 source file.

This PR adds a conversion function and respective tests.

Closes #523 