### PR TITLE
add a separate error for names with wrong type and remove such keys

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ message:
   If you use this software, please cite it using the
   metadata from this file.
 type: software
-version: 0.10.6
+version: 0.10.7
 authors:
   - given-names: Sherjeel
     family-names: Shabih

--- a/src/pynxtools/data/NXtest.nxdl.xml
+++ b/src/pynxtools/data/NXtest.nxdl.xml
@@ -45,7 +45,7 @@
         </group>
         <group type="NXdata" name="specified_group" nameType="specified">
             <doc>A group with a name and nameType="specified".</doc>
-            <field name="specified_field" nameType="specified" type="NX_FLOAT" units="NX_ANY" >
+            <field name="specified_field" nameType="specified" type="NX_FLOAT" units="NX_ANY">
                 <attribute name="specified_attr_in_field" nameType="specified"/>
             </field>
             <attribute name="specified_attr"/>

--- a/src/pynxtools/data/NXtest.nxdl.xml
+++ b/src/pynxtools/data/NXtest.nxdl.xml
@@ -45,8 +45,8 @@
         </group>
         <group type="NXdata" name="specified_group" nameType="specified">
             <doc>A group with a name and nameType="specified".</doc>
-            <field name="specified_field" type="NX_FLOAT" units="NX_ANY">
-                <attribute name="specified_attr_in_field"/>
+            <field name="specified_field" nameType="specified" type="NX_FLOAT" units="NX_ANY" >
+                <attribute name="specified_attr_in_field" nameType="specified"/>
             </field>
             <attribute name="specified_attr"/>
         </group>

--- a/src/pynxtools/dataconverter/convert.py
+++ b/src/pynxtools/dataconverter/convert.py
@@ -176,17 +176,11 @@ def transfer_data_into_template(
     for entry_name in entry_names:
         helpers.write_nexus_def_to_entry(data, entry_name, nxdl_name)
     if not skip_verify:
-        valid, keys_to_remove = validate_dict_against(
+        valid = validate_dict_against(
             nxdl_name,
             data,
             ignore_undocumented=ignore_undocumented,
         )
-
-        # remove attributes that belong to non-existing fields
-
-        for key in keys_to_remove:
-            # data.__delitem__(key)
-            del data[key]
 
         if fail and not valid:
             raise ValidationFailed(

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -153,7 +153,7 @@ class Collector:
                 f"Length of axis {path} does not match to {value} in dimension {args[0]}"
             )
         elif log_type == ValidationProblem.KeyToBeRemoved:
-            logger.warning(f"The attribute {path} will not be written.")
+            logger.warning(f"The {value} {path} will not be written.")
         elif log_type == ValidationProblem.InvalidConceptForNonVariadic:
             value = cast(Any, value)
             log_text = f"Given {value.type} name '{path}' conflicts with the non-variadic name '{value}'"

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -70,6 +70,7 @@ class ValidationProblem(Enum):
     InvalidConceptForNonVariadic = 22
     ReservedSuffixWithoutField = 23
     ReservedPrefixInWrongContext = 24
+    InvalidNexusTypeForNamedConcept = 25
 
 
 class Collector:
@@ -169,6 +170,12 @@ class Collector:
             if value != "<unknown>":
                 log_text += f" It is only valid in the context of {value}."
             logger.error(log_text)
+        elif log_type == ValidationProblem.InvalidNexusTypeForNamedConcept:
+            value = cast(Any, value)
+            logger.error(
+                f"The type ('{args[0] if args else '<unknown>'}') of the given concept '{path}' "
+                f"conflicts with another existing concept of the same name, which is of type '{value.type}')."
+            )
 
     def collect_and_log(
         self,

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -22,7 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime, timezone
-from enum import Enum
+from enum import Enum, auto
 from functools import lru_cache
 from typing import Any, Callable, List, Optional, Tuple, Union, Sequence, cast
 
@@ -46,31 +46,32 @@ logger = logging.getLogger("pynxtools")
 
 
 class ValidationProblem(Enum):
-    UnitWithoutDocumentation = 1
-    InvalidEnum = 2
-    OpenEnumWithNewItem = 3
-    MissingRequiredGroup = 4
-    MissingRequiredField = 5
-    MissingRequiredAttribute = 6
-    InvalidType = 7
-    InvalidDatetime = 8
-    IsNotPosInt = 9
-    ExpectedGroup = 10
-    MissingDocumentation = 11
-    MissingUnit = 12
-    ChoiceValidationError = 13
-    UnitWithoutField = 14
-    AttributeForNonExistingField = 15
-    BrokenLink = 16
-    FailedNamefitting = 17
-    NXdataMissingSignalData = 18
-    NXdataMissingAxisData = 19
-    NXdataAxisMismatch = 20
-    KeyToBeRemoved = 21
-    InvalidConceptForNonVariadic = 22
-    ReservedSuffixWithoutField = 23
-    ReservedPrefixInWrongContext = 24
-    InvalidNexusTypeForNamedConcept = 25
+    UnitWithoutDocumentation = auto()
+    InvalidEnum = auto()
+    OpenEnumWithNewItem = auto()
+    MissingRequiredGroup = auto()
+    MissingRequiredField = auto()
+    MissingRequiredAttribute = auto()
+    InvalidType = auto()
+    InvalidDatetime = auto()
+    IsNotPosInt = auto()
+    ExpectedGroup = auto()
+    ExpectedField = auto()
+    MissingDocumentation = auto()
+    MissingUnit = auto()
+    ChoiceValidationError = auto()
+    UnitWithoutField = auto()
+    AttributeForNonExistingField = auto()
+    BrokenLink = auto()
+    FailedNamefitting = auto()
+    NXdataMissingSignalData = auto()
+    NXdataMissingAxisData = auto()
+    NXdataAxisMismatch = auto()
+    KeyToBeRemoved = auto()
+    InvalidConceptForNonVariadic = auto()
+    ReservedSuffixWithoutField = auto()
+    ReservedPrefixInWrongContext = auto()
+    InvalidNexusTypeForNamedConcept = auto()
 
 
 class Collector:
@@ -97,9 +98,9 @@ class Collector:
                 f"The value at {path} does not match with the enumerated items from the open enumeration: {value}."
             )
         elif log_type == ValidationProblem.MissingRequiredGroup:
-            logger.warning(f"The required group, {path}, hasn't been supplied.")
+            logger.error(f"The required group, {path}, hasn't been supplied.")
         elif log_type == ValidationProblem.MissingRequiredField:
-            logger.warning(
+            logger.error(
                 f"The data entry corresponding to {path} is required "
                 "and hasn't been supplied by the reader.",
             )
@@ -119,9 +120,9 @@ class Collector:
                 f"The value at {path} should be a positive int, but is {value}."
             )
         elif log_type == ValidationProblem.ExpectedGroup:
-            logger.warning(
-                f"Expected a group at {path} but found a field or attribute."
-            )
+            logger.error(f"Expected a group at {path} but found a field or attribute.")
+        elif log_type == ValidationProblem.ExpectedField:
+            logger.error(f"Expected a field at {path} but found a group.")
         elif log_type == ValidationProblem.MissingDocumentation:
             if "@" in path.rsplit("/")[-1]:
                 logger.warning(f"Attribute {path} written without documentation.")
@@ -141,7 +142,7 @@ class Collector:
                 "but the field does not exist."
             )
         elif log_type == ValidationProblem.BrokenLink:
-            logger.warning(f"Broken link at {path} to {value}")
+            logger.warning(f"Broken link at {path} to {value}.")
         elif log_type == ValidationProblem.FailedNamefitting:
             logger.warning(f"Found no namefit of {path} in {value}.")
         elif log_type == ValidationProblem.NXdataMissingSignalData:

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -174,7 +174,7 @@ class Collector:
             value = cast(Any, value)
             logger.error(
                 f"The type ('{args[0] if args else '<unknown>'}') of the given concept '{path}' "
-                f"conflicts with another existing concept of the same name, which is of type '{value.type}')."
+                f"conflicts with another existing concept of the same name, which is of type '{value.type}'."
             )
 
     def collect_and_log(

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -523,7 +523,7 @@ def validate_dict_against(
 
         resolved_keys = copy.deepcopy(keys)
         for key, value in keys.copy().items():
-            if isinstance(value, dict) and len(value) == 1 and "link" in value:
+            if isinstance(value, dict) and "link" in value:
                 key_path = f"{prev_path}/{key}" if prev_path else key
                 current_keys = nested_keys
                 link_key = None

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -629,7 +629,7 @@ def validate_dict_against(
 
         key_len = len(key_components)
 
-        expected_types = None
+        expected_types = []
         for ind, name in enumerate(key_components):
             index = ind + 1
             children_to_check = [
@@ -649,7 +649,7 @@ def validate_dict_against(
 
         return node
 
-    def is_documented(key: str, tree: NexusNode) -> Tuple[bool, bool]:
+    def is_documented(key: str, tree: NexusNode) -> bool:
         if mapping.get(key) is None:
             # This value is not really set. Skip checking its documentation.
             return True

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -194,7 +194,6 @@ def best_namefit_of(
                         or (type_attr := elem.attrib.get("type"))
                         and len(type_attr) > 2
                     ]
-
                     if concept_name not in inherited_names:
                         if node.type == "group":
                             if concept_name != node.nx_class[2:].upper():
@@ -662,12 +661,13 @@ def validate_dict_against(
             node = add_best_matches_for(key, tree, check_types=True)
         except TypeError:
             node = None
+            nx_type = "attribute" if key.split("/")[-1].startswith("@") else "field"
             keys_to_remove.append(key)
 
             collector.collect_and_log(
                 key,
                 ValidationProblem.KeyToBeRemoved,
-                None,
+                nx_type,
             )
 
         if node is None:
@@ -800,7 +800,7 @@ def validate_dict_against(
                         collector.collect_and_log(
                             key,
                             ValidationProblem.KeyToBeRemoved,
-                            None,
+                            "attribute",
                         )
         return keys_to_remove
 
@@ -1087,7 +1087,7 @@ def validate_dict_against(
                 collector.collect_and_log(
                     not_visited_key,
                     ValidationProblem.KeyToBeRemoved,
-                    None,
+                    "attribute",
                 )
                 keys_to_remove.append(not_visited_key)
             else:
@@ -1134,7 +1134,7 @@ def validate_dict_against(
                     collector.collect_and_log(
                         not_visited_key,
                         ValidationProblem.KeyToBeRemoved,
-                        None,
+                        "attribute",
                     )
                     keys_to_remove.append(not_visited_key)
                     continue

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 import re
+import copy
 from collections import defaultdict
 from functools import reduce
 from operator import getitem
@@ -227,7 +228,7 @@ def best_namefit_of(
 
 def validate_dict_against(
     appdef: str, mapping: MutableMapping[str, Any], ignore_undocumented: bool = False
-) -> Tuple[bool, List]:
+) -> bool:
     """
     Validates a mapping against the NeXus tree for application definition `appdef`.
 
@@ -244,7 +245,6 @@ def validate_dict_against(
 
     Returns:
         bool: True if the mapping is valid according to `appdef`, False otherwise.
-        List: list of keys in mapping that correspond to attributes of non-existing fields
     """
 
     def get_variations_of(node: NexusNode, keys: Mapping[str, Any]) -> List[str]:
@@ -416,6 +416,7 @@ def validate_dict_against(
             for x in keys
             if x not in [signal, *axes, *indices, *errors, *aux_signals]
         }
+        remaining_keys = _follow_link(remaining_keys, prev_path)
         recurse_tree(
             node,
             remaining_keys,
@@ -455,24 +456,34 @@ def validate_dict_against(
             return
 
         for variant in variants:
+            variant_path = f"{prev_path}/{variant}"
             if variant in [node.name for node in node.parent_of]:
                 # Don't process if this is actually a sub-variant of this group
                 continue
             nx_class, _ = split_class_and_name_of(variant)
             if not isinstance(keys[variant], Mapping):
+                # Groups should have subelements
                 if nx_class is not None:
                     collector.collect_and_log(
-                        f"{prev_path}/{variant}",
+                        variant_path,
                         ValidationProblem.ExpectedGroup,
                         None,
                     )
+                    # TODO: decide if we want to remove such keys
+                    # collector.collect_and_log(
+                    #     variant_path,
+                    #     ValidationProblem.KeyToBeRemoved,
+                    #     node.type,
+                    # )
+                    # keys_to_remove.append(not_visited_key)
                 continue
             if node.nx_class == "NXdata":
-                handle_nxdata(node, keys[variant], prev_path=f"{prev_path}/{variant}")
+                handle_nxdata(node, keys[variant], prev_path=variant_path)
             if node.nx_class == "NXcollection":
                 return
             else:
-                recurse_tree(node, keys[variant], prev_path=f"{prev_path}/{variant}")
+                variant_keys = _follow_link(keys[variant], variant_path)
+                recurse_tree(node, variant_keys, prev_path=variant_path)
 
     def remove_from_not_visited(path: str) -> str:
         if path in not_visited:
@@ -480,28 +491,64 @@ def validate_dict_against(
         return path
 
     def _follow_link(
-        keys: Optional[Mapping[str, Any]], prev_path: str
+        keys: Optional[Mapping[str, Any]], prev_path: str, p=False
     ) -> Optional[Any]:
+        """
+        Resolves internal dictionary "links" by replacing any keys containing a
+        {"link": "/path/to/target"} structure with the actual referenced content.
+
+        Note that the keys are only replaced in copies of the incoming keys, NOT in
+        the gloval mapping. That is, links are resolved for checking, but we still write
+        links into the HDF5 file.
+
+        This function traverses the mapping and recursively resolves any keys that
+        contain a "link" to another path (relative to the global template).
+        If the link cannot be resolved, the issue is logged.
+
+        Args:
+            keys (Optional[Mapping[str, Any]]): The dictionary structure to process.
+                May be None or a non-dict value, in which case it's returned as-is.
+            prev_path (str): The path leading up to the current `keys` context, used
+                for logging and error reporting.
+
+        Returns:
+            Optional[Any]: A dictionary with resolved links, the original value if
+            `keys` is not a dict, or None if `keys` is None.
+        """
         if keys is None:
             return None
-        if len(keys) == 1 and "link" in keys:
-            current_keys = nested_keys
-            link_key = None
-            for path_elem in keys["link"][1:].split("/"):
+
+        if not isinstance(keys, dict):
+            return keys
+
+        resolved_keys = copy.deepcopy(keys)
+        for key, value in keys.copy().items():
+            if isinstance(value, dict) and len(value) == 1 and "link" in value:
+                key_path = f"{prev_path}/{key}" if prev_path else key
+                current_keys = nested_keys
                 link_key = None
-                for dict_path_elem in current_keys:
-                    _, hdf_name = split_class_and_name_of(dict_path_elem)
-                    if hdf_name == path_elem:
-                        link_key = hdf_name
-                        break
+                for path_elem in value["link"][1:].split("/"):
+                    link_key = None
+                    for dict_path_elem in current_keys:
+                        _, hdf_name = split_class_and_name_of(dict_path_elem)
+                        if hdf_name == path_elem:
+                            link_key = hdf_name
+                            current_keys = current_keys[dict_path_elem]
+                            break
+
                 if link_key is None:
                     collector.collect_and_log(
-                        prev_path, ValidationProblem.BrokenLink, keys["link"]
+                        key_path, ValidationProblem.BrokenLink, value["link"]
                     )
-                    return None
-                current_keys = current_keys[dict_path_elem]
-            return current_keys
-        return keys
+                    collector.collect_and_log(
+                        key_path,
+                        ValidationProblem.KeyToBeRemoved,
+                        "key",
+                    )
+                    del resolved_keys[key]
+                else:
+                    resolved_keys[key] = current_keys
+        return resolved_keys
 
     def handle_field(node: NexusNode, keys: Mapping[str, Any], prev_path: str):
         full_path = remove_from_not_visited(f"{prev_path}/{node.name}")
@@ -515,6 +562,26 @@ def validate_dict_against(
             return
 
         for variant in variants:
+            variant_path = f"{prev_path}/{variant}"
+
+            if isinstance(keys[variant], Mapping) and not all(
+                k.startswith("@") for k in keys[variant]
+            ):
+                # A field should not have a dict of keys that are _not_ all attributes,
+                # i.e. no sub-fields or sub-groups.
+                collector.collect_and_log(
+                    variant_path,
+                    ValidationProblem.ExpectedField,
+                    None,
+                )
+                # TODO: decide if we want to remove such keys
+                # collector.collect_and_log(
+                #     variant_path,
+                #     ValidationProblem.KeyToBeRemoved,
+                #     node.type,
+                # )
+                # keys_to_remove.append(variant_path)
+                continue
             if node.optionality == "required" and isinstance(keys[variant], Mapping):
                 # Check if all fields in the dict are actual attributes (startswith @)
                 all_attrs = True
@@ -524,44 +591,47 @@ def validate_dict_against(
                         break
                 if all_attrs:
                     collector.collect_and_log(
-                        f"{prev_path}/{variant}", missing_type_err.get(node.type), None
+                        variant_path, missing_type_err.get(node.type), None
                     )
                     collector.collect_and_log(
-                        f"{prev_path}/{variant}",
+                        variant_path,
                         ValidationProblem.AttributeForNonExistingField,
                         None,
                     )
                     return
-            if variant not in keys or mapping.get(f"{prev_path}/{variant}") is None:
+            if variant not in keys or mapping.get(variant_path) is None:
                 continue
 
             # Check general validity
-            mapping[f"{prev_path}/{variant}"] = is_valid_data_field(
-                mapping[f"{prev_path}/{variant}"],
+            mapping[variant_path] = is_valid_data_field(
+                mapping[variant_path],
                 node.dtype,
                 node.items,
                 node.open_enum,
-                f"{prev_path}/{variant}",
+                variant_path,
             )
 
-            _ = check_reserved_suffix(f"{prev_path}/{variant}", mapping)
-            _ = check_reserved_prefix(f"{prev_path}/{variant}", mapping, "field")
+            _ = check_reserved_suffix(variant_path, mapping)
+            _ = check_reserved_prefix(variant_path, mapping, "field")
 
             # Check unit category
             if node.unit is not None:
                 remove_from_not_visited(f"{prev_path}/{variant}/@units")
                 if f"{variant}@units" not in keys:
                     collector.collect_and_log(
-                        f"{prev_path}/{variant}",
+                        variant_path,
                         ValidationProblem.MissingUnit,
                         node.unit,
                     )
                 # TODO: Check unit with pint
 
+            field_attributes = get_field_attributes(variant, keys)
+            field_attributes = _follow_link(field_attributes, variant_path)
+
             recurse_tree(
                 node,
-                get_field_attributes(variant, keys),
-                prev_path=f"{prev_path}/{variant}",
+                field_attributes,
+                prev_path=variant_path,
             )
 
     def handle_attribute(node: NexusNode, keys: Mapping[str, Any], prev_path: str):
@@ -577,18 +647,19 @@ def validate_dict_against(
             return
 
         for variant in variants:
-            mapping[
+            variant_path = (
                 f"{prev_path}/{variant if variant.startswith('@') else f'@{variant}'}"
-            ] = is_valid_data_field(
+            )
+            mapping[variant_path] = is_valid_data_field(
                 mapping[
                     f"{prev_path}/{variant if variant.startswith('@') else f'@{variant}'}"
                 ],
                 node.dtype,
                 node.items,
                 node.open_enum,
-                f"{prev_path}/{variant if variant.startswith('@') else f'@{variant}'}",
+                variant_path,
             )
-            _ = check_reserved_prefix(f"{prev_path}/{variant}", mapping, "attribute")
+            _ = check_reserved_prefix(variant_path, mapping, "attribute")
 
     def handle_choice(node: NexusNode, keys: Mapping[str, Any], prev_path: str):
         global collector
@@ -662,13 +733,13 @@ def validate_dict_against(
         except TypeError:
             node = None
             nx_type = "attribute" if key.split("/")[-1].startswith("@") else "field"
-            keys_to_remove.append(key)
 
             collector.collect_and_log(
                 key,
                 ValidationProblem.KeyToBeRemoved,
                 nx_type,
             )
+            keys_to_remove.append(key)
 
         if node is None:
             key_path = key.replace("@", "")
@@ -690,7 +761,49 @@ def validate_dict_against(
             return True
 
         if isinstance(mapping[key], dict) and "link" in mapping[key]:
-            # TODO: Follow link and check consistency with current field
+            resolved_link = _follow_link({key: mapping[key]}, "")
+
+            is_mapping = isinstance(resolved_link[key], Mapping)
+
+            if node.type == "group" and not is_mapping:
+                # Groups must have subelements
+                collector.collect_and_log(
+                    key,
+                    ValidationProblem.ExpectedGroup,
+                    None,
+                )
+                # TODO: decide if we want to remove such keys
+                # collector.collect_and_log(
+                #     key,
+                #     ValidationProblem.KeyToBeRemoved,
+                #     "group",
+                # )
+                # keys_to_remove.append(key)
+                return False
+
+            elif node.type == "field":
+                # A field should not have a dict of keys that are _not_ all attributes,
+                # i.e. no sub-fields or sub-groups.
+                if is_mapping and not all(
+                    k.startswith("@") for k in resolved_link[key]
+                ):
+                    collector.collect_and_log(
+                        key,
+                        ValidationProblem.ExpectedField,
+                        None,
+                    )
+                    # TODO: decide if we want to remove such keys
+                    # collector.collect_and_log(
+                    #     key,
+                    #     ValidationProblem.KeyToBeRemoved,
+                    #     "field",
+                    # )
+                    # keys_to_remove.append(key)
+                    # return False
+                resolved_link[key] = is_valid_data_field(
+                    resolved_link[key], node.dtype, node.items, node.open_enum, key
+                )
+
             return True
 
         if "@" not in key and node.type != "field":
@@ -727,7 +840,6 @@ def validate_dict_against(
         for child in node.children:
             if ignore_names is not None and child.name in ignore_names:
                 continue
-            keys = _follow_link(keys, prev_path)
             if keys is None:
                 return
 
@@ -735,23 +847,18 @@ def validate_dict_against(
 
     def check_attributes_of_nonexisting_field(
         node: NexusNode,
-    ) -> list:
+    ):
         """
             This method runs through the mapping dictionary and checks if there are any
             attributes assigned to the fields (not groups!) which are not explicitly
             present in the mapping.
             If there are any found, a warning is logged and the corresponding items are
-            added to the list returned by the method.
+            added to the list that stores all keys that shall be removed.
 
         Args:
             node (NexusNode): the tree generated from application definition.
 
-        Returns:
-            list: list of keys in mapping that correspond to attributes of
-            non-existing fields
         """
-
-        keys_to_remove = []
 
         for key in mapping:
             last_index = key.rfind("/")
@@ -795,14 +902,8 @@ def validate_dict_against(
                         collector.collect_and_log(
                             key[0:last_index],
                             ValidationProblem.AttributeForNonExistingField,
-                            None,
-                        )
-                        collector.collect_and_log(
-                            key,
-                            ValidationProblem.KeyToBeRemoved,
                             "attribute",
                         )
-        return keys_to_remove
 
     def check_type_with_tree(
         node: NexusNode,
@@ -1062,13 +1163,16 @@ def validate_dict_against(
         "choice": handle_choice,
     }
 
+    keys_to_remove = []
+
     tree = generate_tree_from(appdef)
     collector.clear()
     nested_keys = build_nested_dict_from(mapping)
     not_visited = list(mapping)
+    keys = _follow_link(nested_keys, "")
     recurse_tree(tree, nested_keys)
 
-    keys_to_remove = check_attributes_of_nonexisting_field(tree)
+    check_attributes_of_nonexisting_field(tree)
 
     for not_visited_key in not_visited:
         # TODO: remove again if "@target"/"@reference" is sorted out by NIAC
@@ -1160,7 +1264,11 @@ def validate_dict_against(
     # clear lru_cache
     NexusNode.search_add_child_for.cache_clear()
 
-    return (not collector.has_validation_problems(), keys_to_remove)
+    # remove keys that are incorrect
+    for key in set(keys_to_remove):
+        del mapping[key]
+
+    return not collector.has_validation_problems()
 
 
 def populate_full_tree(node: NexusNode, max_depth: Optional[int] = 5, depth: int = 0):
@@ -1194,4 +1302,4 @@ def populate_full_tree(node: NexusNode, max_depth: Optional[int] = 5, depth: int
 def validate_data_dict(
     _: MutableMapping[str, Any], read_data: MutableMapping[str, Any], root: ET._Element
 ) -> bool:
-    return validate_dict_against(root.attrib["name"], read_data)[0]
+    return validate_dict_against(root.attrib["name"], read_data)

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -636,12 +636,16 @@ def validate_dict_against(
                 node.search_add_child_for(child)
                 for child in node.get_all_direct_children_names()
             ]
+
             if index < key_len - 1:
                 expected_types = ["group"]
             elif index == key_len - 1:
                 expected_types = ["group"] if not is_last_attr else ["group", "field"]
             elif index == key_len:
                 expected_types = ["attribute"] if is_last_attr else ["field"]
+                if "link" in str(mapping.get(key, "")):
+                    expected_types += ["group"]
+
             node = best_namefit_of(name, children_to_check, expected_types, check_types)
 
             if node is None:

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -898,12 +898,18 @@ def validate_dict_against(
                         type_of_parent_from_tree == "group"
                         or type_of_parent_from_tree is None
                     ):
-                        keys_to_remove.append(key)
                         collector.collect_and_log(
                             key[0:last_index],
                             ValidationProblem.AttributeForNonExistingField,
                             "attribute",
                         )
+                        collector.collect_and_log(
+                            key,
+                            ValidationProblem.KeyToBeRemoved,
+                            "attribute",
+                        )
+                        keys_to_remove.append(key)
+                        remove_from_not_visited(key)
 
     def check_type_with_tree(
         node: NexusNode,

--- a/src/pynxtools/dataconverter/writer.py
+++ b/src/pynxtools/dataconverter/writer.py
@@ -250,7 +250,12 @@ class Writer:
             attrs = self.__nxdl_to_attrs(parent_path)
 
             if attrs is not None:
-                grp.attrs["NX_class"] = attrs["type"]
+                if nx_class := attrs.get("type"):
+                    grp.attrs["NX_class"] = nx_class
+                else:
+                    logger.error(
+                        f"No attribute 'NX_class' could be written for {parent_path}."
+                    )
             return grp
         return self.output_nexus[parent_path_hdf5]
 

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -117,6 +117,6 @@ def test_has_correct_read_func(reader, caplog):
                 with caplog.at_level(logging.WARNING):
                     validate_dict_against(
                         supported_nxdl, read_data, ignore_undocumented=True
-                    )[0]
+                    )
 
                 print(caplog.text)

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -861,7 +861,7 @@ TEMPLATE["required"][
                 {"link": "/my_entry/nxodd_name/char_value"},
             ),
             [],
-            id="base-class-links-with-matching-nexus-types",
+            id="baseclass-links-with-matching-nexus-types",
         ),
         pytest.param(
             alter_dict(
@@ -878,7 +878,7 @@ TEMPLATE["required"][
                 "Field /ENTRY[my_entry]/SAMPLE[my_sample] written without documentation.",
                 "Expected a field at /ENTRY[my_entry]/SAMPLE[my_sample]/name but found a group.",
             ],
-            id="base-class-links-with-wrong-nexus-types",
+            id="baseclass-links-with-wrong-nexus-types",
         ),
         pytest.param(
             alter_dict(
@@ -1340,7 +1340,7 @@ TEMPLATE["required"][
             [
                 "Reserved suffix '_weights' was used in /ENTRY[my_entry]/OPTIONAL_group[my_group]/FIELDNAME_weights[some_random_field_weights], but there is no associated field some_random_field.",
             ],
-            id="reserved-suffix-from-base-class",
+            id="reserved-suffix-from-baseclass",
         ),
         pytest.param(
             alter_dict(

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -806,8 +806,8 @@ TEMPLATE["required"][
             ),
             [
                 "The type ('field') of the given concept 'identified_calibration' conflicts with another "
-                "existing concept of the same name, which is of type 'group').",
-                "The attribute /ENTRY[my_entry]/identified_calibration will not be written.",
+                "existing concept of the same name, which is of type 'group'.",
+                "The field /ENTRY[my_entry]/identified_calibration will not be written.",
             ],
             id="field-instead-of-named-group",
         ),

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -787,6 +787,32 @@ TEMPLATE["required"][
         ),
         pytest.param(
             alter_dict(
+                TEMPLATE,
+                "/ENTRY[my_entry]/identified_calibration/identifier_1/some_field",
+                "123",
+            ),
+            [
+                "The type ('group') of the given concept 'identifier_1' conflicts with another "
+                "existing concept of the same name, which is of type 'field').",
+                "The attribute /ENTRY[my_entry]/identified_calibration/identifier_1/some_field will not be written.",
+            ],
+            id="group-instead-of-named-field",
+        ),
+        pytest.param(
+            alter_dict(
+                TEMPLATE,
+                "/ENTRY[my_entry]/identified_calibration",
+                "123",
+            ),
+            [
+                "The type ('field') of the given concept 'identified_calibration' conflicts with another "
+                "existing concept of the same name, which is of type 'group').",
+                "The attribute /ENTRY[my_entry]/identified_calibration will not be written.",
+            ],
+            id="field-instead-of-named-group",
+        ),
+        pytest.param(
+            alter_dict(
                 remove_from_dict(
                     TEMPLATE,
                     "/ENTRY[my_entry]/optional_parent/optional_child",
@@ -1299,8 +1325,6 @@ def test_validate_data_dict(caplog, data_dict, error_messages, request):
             "baseclass-field-with-illegal-unit",
             "open-enum-with-new-item",
             "baseclass-open-enum-with-new-item",
-            "variadic-nxcollection",
-            "nonvariadic-nxcollection",
         ):
             with caplog.at_level(logging.INFO):
                 assert validate_dict_against("NXtest", data_dict)[0]

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -415,7 +415,11 @@ TEMPLATE["required"][
                 "/ENTRY[my_entry]/NXODD_name[nxodd_name]/int_value",
                 {"link": "/a-link"},
             ),
-            [],
+            [
+                "Broken link at /ENTRY[my_entry]/NXODD_name[nxodd_name]/int_value to /a-link.",
+                "The key /ENTRY[my_entry]/NXODD_name[nxodd_name]/int_value will not be written.",
+                "The data entry corresponding to /ENTRY[my_entry]/NXODD_name[nxodd_name]/int_value is required and hasn't been supplied by the reader.",
+            ],
             id="link-dict-instead-of-int",
         ),
         pytest.param(
@@ -792,6 +796,7 @@ TEMPLATE["required"][
                 "123",
             ),
             [
+                "Expected a field at /ENTRY[my_entry]/identified_calibration/identifier_1 but found a group.",
                 "The type ('group') of the given concept 'identifier_1' conflicts with another "
                 "existing concept of the same name, which is of type 'field'.",
                 "The field /ENTRY[my_entry]/identified_calibration/identifier_1/some_field will not be written.",
@@ -810,6 +815,70 @@ TEMPLATE["required"][
                 "The field /ENTRY[my_entry]/identified_calibration will not be written.",
             ],
             id="field-instead-of-named-group",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    remove_from_dict(
+                        TEMPLATE,
+                        "/ENTRY[my_entry]/required_group/description",
+                        "optional",
+                    ),
+                    "/ENTRY[my_entry]/required_group",
+                    {"link": "/my_entry/required_group2"},
+                ),
+                "/ENTRY[my_entry]/OPTIONAL_group[some_group]/required_field",
+                {"link": "/my_entry/specified_group/specified_field"},
+            ),
+            [],
+            id="appdef-links-with-matching-nexus-types",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    TEMPLATE,
+                    "/ENTRY[my_entry]/USER[my_user]",
+                    {"link": "/my_entry/my_group/required_field"},
+                ),
+                "/ENTRY[my_entry]/OPTIONAL_group[some_group]/required_field",
+                {"link": "/my_entry/specified_group"},
+            ),
+            [
+                "Expected a field at /ENTRY[my_entry]/OPTIONAL_group[some_group]/required_field but found a group.",
+                "Expected a group at /ENTRY[my_entry]/USER[my_user] but found a field or attribute.",
+                "Field /ENTRY[my_entry]/USER[my_user] written without documentation.",
+            ],
+            id="appdef-links-with-wrong-nexus-types",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    TEMPLATE,
+                    "/ENTRY[my_entry]/SAMPLE[my_sample]",
+                    {"link": "/my_entry/my_group"},
+                ),
+                "/ENTRY[my_entry]/SAMPLE[my_sample]/name",
+                {"link": "/my_entry/nxodd_name/char_value"},
+            ),
+            [],
+            id="base-class-links-with-matching-nexus-types",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    TEMPLATE,
+                    "/ENTRY[my_entry]/SAMPLE[my_sample]",
+                    {"link": "/my_entry/my_group/required_field"},
+                ),
+                "/ENTRY[my_entry]/SAMPLE[my_sample]/name",
+                {"link": "/my_entry/my_group"},
+            ),
+            [
+                "Expected a group at /ENTRY[my_entry]/SAMPLE[my_sample] but found a field or attribute.",
+                "Field /ENTRY[my_entry]/SAMPLE[my_sample] written without documentation.",
+                "Expected a field at /ENTRY[my_entry]/SAMPLE[my_sample]/name but found a group.",
+            ],
+            id="base-class-links-with-wrong-nexus-types",
         ),
         pytest.param(
             alter_dict(
@@ -1317,7 +1386,7 @@ def test_validate_data_dict(caplog, data_dict, error_messages, request):
 
     if not error_messages:
         with caplog.at_level(logging.WARNING):
-            assert validate_dict_against("NXtest", data_dict)[0]
+            assert validate_dict_against("NXtest", data_dict)
         assert caplog.text == ""
     else:
         if request.node.callspec.id in (
@@ -1327,11 +1396,11 @@ def test_validate_data_dict(caplog, data_dict, error_messages, request):
             "baseclass-open-enum-with-new-item",
         ):
             with caplog.at_level(logging.INFO):
-                assert validate_dict_against("NXtest", data_dict)[0]
+                assert validate_dict_against("NXtest", data_dict)
                 assert error_messages[0] in caplog.text
         else:
             with caplog.at_level(logging.WARNING):
-                assert not validate_dict_against("NXtest", data_dict)[0]
+                assert not validate_dict_against("NXtest", data_dict)
             assert len(caplog.records) == len(error_messages)
             for expected_message, rec in zip(error_messages, caplog.records):
                 assert expected_message == format_error_message(rec.message)

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -793,8 +793,8 @@ TEMPLATE["required"][
             ),
             [
                 "The type ('group') of the given concept 'identifier_1' conflicts with another "
-                "existing concept of the same name, which is of type 'field').",
-                "The attribute /ENTRY[my_entry]/identified_calibration/identifier_1/some_field will not be written.",
+                "existing concept of the same name, which is of type 'field'.",
+                "The field /ENTRY[my_entry]/identified_calibration/identifier_1/some_field will not be written.",
             ],
             id="group-instead-of-named-field",
         ),


### PR DESCRIPTION
The idea is to catch the following situation: a field/group is given that has a name that another group/field at the same level has (and which is therefore reserved).

Approach:
1) Throw and log an error on such cases
2) this error should be separate to the existing checks for concept names
3) if this error is thrown, it should result in that field not to be written at all (i.e., it shall be removed from the template)
