### PR TITLE
Validation check for reserved prefixes and suffixes

### DIFF
--- a/src/pynxtools/data/NXtest.nxdl.xml
+++ b/src/pynxtools/data/NXtest.nxdl.xml
@@ -23,6 +23,15 @@
             <field name="required_field" required="true" type="NX_INT">
                 <doc>A dummy entry to test optional parent check for a required child.</doc>
             </field>
+            <field name="required_field_set" optional="true" type="NX_INT">
+                <doc>A dummy entry to test reserved suffixes.</doc>
+            </field>
+            <field name="some_field_set" optional="true" type="NX_INT">
+                <doc>
+                    A dummy entry to test reserved suffixes where the actual field is not given.
+                    Note that this is not allowed by NeXus, but we do this here to test the validation.
+                </doc>
+            </field>
             <field name="optional_field" optional="true" type="NX_INT">
                 <doc>A dummy entry to test optional parent check for an optional child.</doc>
             </field>

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -69,7 +69,7 @@ class ValidationProblem(Enum):
     KeyToBeRemoved = 21
     InvalidConceptForNonVariadic = 22
     ReservedSuffixWithoutField = 23
-    ReservedPrefixInWrongApplication = 24
+    ReservedPrefixInWrongContext = 24
 
 
 class Collector:
@@ -163,7 +163,7 @@ class Collector:
             logger.warning(
                 f"Reserved suffix {path} was used, but there is no associated field {value}."
             )
-        elif log_type == ValidationProblem.ReservedPrefixInWrongApplication:
+        elif log_type == ValidationProblem.ReservedPrefixInWrongContext:
             log_text = f"Reserved prefix {path} was used in key {args[0] if args else '<unknown>'}, but is not valid here."
             if value != "<unknown>":
                 log_text += f" It is only valid in the context of {value}."

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -165,6 +165,7 @@ class Collector:
             )
         elif log_type == ValidationProblem.ReservedPrefixInWrongContext:
             log_text = f"Reserved prefix {path} was used in key {args[0] if args else '<unknown>'}, but is not valid here."
+            # Note that value=None" gets converted to "<unknown>"
             if value != "<unknown>":
                 log_text += f" It is only valid in the context of {value}."
             logger.error(log_text)

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -68,6 +68,8 @@ class ValidationProblem(Enum):
     NXdataAxisMismatch = 20
     KeyToBeRemoved = 21
     InvalidConceptForNonVariadic = 22
+    ReservedSuffixWithoutField = 23
+    ReservedPrefixInWrongApplication = 24
 
 
 class Collector:
@@ -157,6 +159,15 @@ class Collector:
             if value.type == "group":
                 log_text += f", which should be of type {value.nx_class}."
             logger.warning(log_text)
+        elif log_type == ValidationProblem.ReservedSuffixWithoutField:
+            logger.warning(
+                f"Reserved suffix {path} was used, but there is no associated field {value}."
+            )
+        elif log_type == ValidationProblem.ReservedPrefixInWrongApplication:
+            log_text = f"Reserved prefix {path} was used in key {args[0] if args else '<unknown>'}, but is not valid here."
+            if value != "<unknown>":
+                log_text += f" It is only valid in the context of {value}."
+            logger.error(log_text)
 
     def collect_and_log(
         self,

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -161,7 +161,7 @@ class Collector:
             logger.warning(log_text)
         elif log_type == ValidationProblem.ReservedSuffixWithoutField:
             logger.warning(
-                f"Reserved suffix {path} was used, but there is no associated field {value}."
+                f"Reserved suffix '{args[0]}' was used in {path}, but there is no associated field {value}."
             )
         elif log_type == ValidationProblem.ReservedPrefixInWrongContext:
             log_text = f"Reserved prefix {path} was used in key {args[0] if args else '<unknown>'}, but is not valid here."

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -912,7 +912,8 @@ def validate_dict_against(
         prefixes = reserved_prefixes[nx_type]
 
         if not key.rsplit("/", 1)[-1].startswith(tuple(prefixes.keys())):
-            return True
+            # Ignore this test
+            return False
 
         for prefix, context in prefixes.items():
             if not key.rsplit("/", 1)[-1].startswith(prefix):
@@ -931,17 +932,17 @@ def validate_dict_against(
                 continue
             else:
                 # Check that the prefix is used in the correct application definition.
-                definition_key = (
-                    f"{re.match(r'(/ENTRY\[[^]]+])', key).group(1)}/definition"
-                )
-                if mapping.get(definition_key) != context:
-                    collector.collect_and_log(
-                        prefix,
-                        ValidationProblem.ReservedPrefixInWrongApplication,
-                        context,
-                        key,
-                    )
-                return False
+                match = re.match(r"(/ENTRY\[[^]]+])", key)
+                if match:
+                    definition_key = f"{match.group(1)}/definition"
+                    if mapping.get(definition_key) != context:
+                        collector.collect_and_log(
+                            prefix,
+                            ValidationProblem.ReservedPrefixInWrongApplication,
+                            context,
+                            key,
+                        )
+                    return False
 
         return True
 

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -904,28 +904,20 @@ def validate_dict_against(
 
         for suffix in reserved_suffixes:
             if instance_name.endswith(suffix):
-                associated_field_name = instance_name.rsplit(suffix, 1)[0]
+                associated_field = instance_name.rsplit(suffix, 1)[0]
 
-                # TODO: This strictly limits FIELDNAME_weights[my_field_weights] to match with
-                # either my_field_weights or FIELDNAME[my_field], but AXISNAME[my_field] will
-                # not match.
-
-                possible_fields = [associated_field_name]
-
-                if concept_name:
-                    possible_fields += (
-                        f"{concept_name.rsplit(suffix, 1)[0]}[{associated_field_name}]"
+                if not any(
+                    k.startswith(parent_path + "/")
+                    and (
+                        k.endswith(associated_field)
+                        or k.endswith(f"[{associated_field}]")
                     )
-
-                possible_field_keys = [
-                    f"{parent_path}/{field}" for field in possible_fields
-                ]
-
-                if not any(k in mapping for k in possible_field_keys):
+                    for k in mapping
+                ):
                     collector.collect_and_log(
                         key,
                         ValidationProblem.ReservedSuffixWithoutField,
-                        associated_field_name,
+                        associated_field,
                         suffix,
                     )
                     return False

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -859,7 +859,7 @@ def validate_dict_against(
         # default
         return (False, 0)
 
-    def check_reserved_suffix(key: str, mapping: Dict[str, Any]) -> bool:
+    def check_reserved_suffix(key: str, mapping: MutableMapping[str, Any]) -> bool:
         """Check if an associated field exists for a key with a reserved suffix."""
         reserved_suffixes = (
             "_end",
@@ -889,7 +889,7 @@ def validate_dict_against(
 
     def check_reserved_prefix(
         key: str,
-        mapping: Dict[str, Any],
+        mapping: MutableMapping[str, Any],
         nx_type: Literal["group", "field", "attribute"],
     ) -> bool:
         """Check if a reserved prefix was used in the correct context."""

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -193,9 +193,6 @@ def best_namefit_of(name: str, nodes: Iterable[NexusNode]) -> Optional[NexusNode
                         return None
                 return node
         else:
-            PRINT_HERE = True if "weights" in name else False
-            # if PRINT_HERE:
-            #     print(node)
             if concept_name and concept_name == node.name:
                 if instance_name == node.name:
                     return node
@@ -604,18 +601,12 @@ def validate_dict_against(
         pass
 
     def add_best_matches_for(key: str, node: NexusNode) -> Optional[NexusNode]:
-        PRINT = False  # True if "weights" in key else False
         for name in key[1:].replace("@", "").split("/"):
             children_to_check = [
                 node.search_add_child_for(child)
                 for child in node.get_all_direct_children_names()
             ]
-            if PRINT:
-                print("<<<<<<<", name, node)
             node = best_namefit_of(name, children_to_check)
-            if PRINT:
-                print("\t", children_to_check)
-                print(">>>>>>", node)
 
             if node is None:
                 return None

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -1227,8 +1227,8 @@ TEMPLATE["required"][
                 1,
             ),
             [
-                "Reserved suffix /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_field_set was used, "
-                "but there is no associated field /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_field."
+                "Reserved suffix '_set' was used in /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_field_set, "
+                "but there is no associated field some_field."
             ],
             id="reserved-suffix-from-appdef",
         ),
@@ -1236,16 +1236,14 @@ TEMPLATE["required"][
             alter_dict(
                 alter_dict(
                     TEMPLATE,
-                    "/ENTRY[my_entry]/OPTIONAL_group[my_group]/required_field_weights",
+                    "/ENTRY[my_entry]/OPTIONAL_group[my_group]/FIELDNAME_weights[required_field_weights]",
                     0.1,
                 ),
-                "/ENTRY[my_entry]/OPTIONAL_group[my_group]/some_random_field_weights",
+                "/ENTRY[my_entry]/OPTIONAL_group[my_group]/FIELDNAME_weights[some_random_field_weights]",
                 0.1,
             ),
             [
-                "Field /ENTRY[my_entry]/OPTIONAL_group[my_group]/required_field_weights written without documentation.",
-                "Reserved suffix /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_random_field_weights was used, but there is no associated field /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_random_field.",
-                "Field /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_random_field_weights written without documentation.",
+                "Reserved suffix '_weights' was used in /ENTRY[my_entry]/OPTIONAL_group[my_group]/FIELDNAME_weights[some_random_field_weights], but there is no associated field some_random_field.",
             ],
             id="reserved-suffix-from-base-class",
         ),

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -1243,6 +1243,7 @@ TEMPLATE["required"][
                 0.1,
             ),
             [
+                "Field /ENTRY[my_entry]/OPTIONAL_group[my_group]/required_field_weights written without documentation.",
                 "Reserved suffix /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_random_field_weights was used, but there is no associated field /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_random_field.",
                 "Field /ENTRY[my_entry]/OPTIONAL_group[my_group]/some_random_field_weights written without documentation.",
             ],
@@ -1252,14 +1253,18 @@ TEMPLATE["required"][
             alter_dict(
                 alter_dict(
                     alter_dict(
-                        TEMPLATE,
-                        "/ENTRY[my_entry]/OPTIONAL_group[my_group]/@BLUESKY_attr",
+                        alter_dict(
+                            TEMPLATE,
+                            "/ENTRY[my_entry]/OPTIONAL_group[my_group]/@BLUESKY_attr",
+                            "some text",
+                        ),
+                        "/ENTRY[my_entry]/OPTIONAL_group[my_group]/@DECTRIS_attr",
                         "some text",
                     ),
-                    "/ENTRY[my_entry]/OPTIONAL_group[my_group]/@DECTRIS_attr",
+                    "/ENTRY[my_entry]/OPTIONAL_group[my_group]/DECTRIS_field",
                     "some text",
                 ),
-                "/ENTRY[my_entry]/OPTIONAL_group[my_group]/DECTRIS_field",
+                "/ENTRY[my_entry]/OPTIONAL_group[my_group]/@NX_attr",
                 "some text",
             ),
             [
@@ -1271,6 +1276,7 @@ TEMPLATE["required"][
                 "Reserved prefix DECTRIS_ was used in key /ENTRY[my_entry]/OPTIONAL_group[my_group]/DECTRIS_field, but is not valid here. "
                 "It is only valid in the context of NXmx.",
                 "Field /ENTRY[my_entry]/OPTIONAL_group[my_group]/DECTRIS_field written without documentation.",
+                "Attribute /ENTRY[my_entry]/OPTIONAL_group[my_group]/@NX_attr written without documentation.",
             ],
             id="reserved-prefix",
         ),
@@ -1278,7 +1284,6 @@ TEMPLATE["required"][
 )
 def test_validate_data_dict(caplog, data_dict, error_messages, request):
     """Unit test for the data validation routine."""
-    # validate_dict_against("NXtest", data_dict)[0]
 
     def format_error_message(msg: str) -> str:
         for prefix in ("ERROR:", "WARNING:"):


### PR DESCRIPTION
NeXus defines [reserved prefixes and suffixes](https://manual.nexusformat.org/datarules.html#index-5) that may only be used in a certain context.

Here, we implement checks for both prefixes and suffixes:
- **prefixes**: these can only be used within a certain context (e.g. `DECTRIS_` prefix is only valid for attributes in `DECTRIS` detectors, i.e., in `NXmx`). Any other use is prohibited. We check the context and log an error if such attributes exist out of context. Note that for some reserved prefixes, we can not write them from pynxtools, so their use is disallowed. We still write these attributes as undocumented, though (could be removed).
- **suffixes**: These are already explicitly defined in NeXus (mostly in `NXobject`, but also in `NXdata` and `NXtransformations`). Note that you can use these suffixes freely outside of their scope (e.g. you can use `FIELDNAME_end`) anyway you like _if_ you are not within `NXtransformations`. Here, we basically check that if a reserved suffix is used, the initial field also exists (e.g. if we define a field `my_field_weights`, we check that `my_field` exists as well.

