### PR TITLE
handle variable-name attributes in writer

### DIFF
--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -590,8 +590,10 @@ def get_name_from_data_dict_entry(entry: str) -> str:
     results = get_regex().search(entry)
     if results is None:
         return entry
+
     if entry[0] == "@":
-        return "@" + results.group(1)
+        name = results.group(1)
+        return name if name.startswith("@") else "@" + name
     return results.group(1)
 
 


### PR DESCRIPTION
For variable-name attributes, we are now using this notation in the template: `"@AXISNAME_indices[energy_indices]"` (see also https://github.com/FAIRmat-NFDI/pynxtools-mpes/pull/52/files). The existing logic was interpreting this to write an HDF5 attribute  `@energy_indices`, but we don't actuallly want to write the `@` into the file. With this PR, the name of the attribute is `energy_indices`, as expected.

