### PR TITLE
Follow links and resolve

### DIFF
--- a/src/pynxtools/dataconverter/convert.py
+++ b/src/pynxtools/dataconverter/convert.py
@@ -176,17 +176,11 @@ def transfer_data_into_template(
     for entry_name in entry_names:
         helpers.write_nexus_def_to_entry(data, entry_name, nxdl_name)
     if not skip_verify:
-        valid, keys_to_remove = validate_dict_against(
+        valid = validate_dict_against(
             nxdl_name,
             data,
             ignore_undocumented=ignore_undocumented,
         )
-
-        # remove attributes that belong to non-existing fields
-
-        for key in keys_to_remove:
-            # data.__delitem__(key)
-            del data[key]
 
         if fail and not valid:
             raise ValidationFailed(

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -22,7 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime, timezone
-from enum import Enum
+from enum import Enum, auto
 from functools import lru_cache
 from typing import Any, Callable, List, Optional, Tuple, Union, Sequence, cast
 
@@ -46,31 +46,32 @@ logger = logging.getLogger("pynxtools")
 
 
 class ValidationProblem(Enum):
-    UnitWithoutDocumentation = 1
-    InvalidEnum = 2
-    OpenEnumWithNewItem = 3
-    MissingRequiredGroup = 4
-    MissingRequiredField = 5
-    MissingRequiredAttribute = 6
-    InvalidType = 7
-    InvalidDatetime = 8
-    IsNotPosInt = 9
-    ExpectedGroup = 10
-    MissingDocumentation = 11
-    MissingUnit = 12
-    ChoiceValidationError = 13
-    UnitWithoutField = 14
-    AttributeForNonExistingField = 15
-    BrokenLink = 16
-    FailedNamefitting = 17
-    NXdataMissingSignalData = 18
-    NXdataMissingAxisData = 19
-    NXdataAxisMismatch = 20
-    KeyToBeRemoved = 21
-    InvalidConceptForNonVariadic = 22
-    ReservedSuffixWithoutField = 23
-    ReservedPrefixInWrongContext = 24
-    InvalidNexusTypeForNamedConcept = 25
+    UnitWithoutDocumentation = auto()
+    InvalidEnum = auto()
+    OpenEnumWithNewItem = auto()
+    MissingRequiredGroup = auto()
+    MissingRequiredField = auto()
+    MissingRequiredAttribute = auto()
+    InvalidType = auto()
+    InvalidDatetime = auto()
+    IsNotPosInt = auto()
+    ExpectedGroup = auto()
+    ExpectedField = auto()
+    MissingDocumentation = auto()
+    MissingUnit = auto()
+    ChoiceValidationError = auto()
+    UnitWithoutField = auto()
+    AttributeForNonExistingField = auto()
+    BrokenLink = auto()
+    FailedNamefitting = auto()
+    NXdataMissingSignalData = auto()
+    NXdataMissingAxisData = auto()
+    NXdataAxisMismatch = auto()
+    KeyToBeRemoved = auto()
+    InvalidConceptForNonVariadic = auto()
+    ReservedSuffixWithoutField = auto()
+    ReservedPrefixInWrongContext = auto()
+    InvalidNexusTypeForNamedConcept = auto()
 
 
 class Collector:
@@ -97,9 +98,9 @@ class Collector:
                 f"The value at {path} does not match with the enumerated items from the open enumeration: {value}."
             )
         elif log_type == ValidationProblem.MissingRequiredGroup:
-            logger.warning(f"The required group, {path}, hasn't been supplied.")
+            logger.error(f"The required group, {path}, hasn't been supplied.")
         elif log_type == ValidationProblem.MissingRequiredField:
-            logger.warning(
+            logger.error(
                 f"The data entry corresponding to {path} is required "
                 "and hasn't been supplied by the reader.",
             )
@@ -119,9 +120,9 @@ class Collector:
                 f"The value at {path} should be a positive int, but is {value}."
             )
         elif log_type == ValidationProblem.ExpectedGroup:
-            logger.warning(
-                f"Expected a group at {path} but found a field or attribute."
-            )
+            logger.error(f"Expected a group at {path} but found a field or attribute.")
+        elif log_type == ValidationProblem.ExpectedField:
+            logger.error(f"Expected a field at {path} but found a group.")
         elif log_type == ValidationProblem.MissingDocumentation:
             if "@" in path.rsplit("/")[-1]:
                 logger.warning(f"Attribute {path} written without documentation.")
@@ -141,7 +142,7 @@ class Collector:
                 "but the field does not exist."
             )
         elif log_type == ValidationProblem.BrokenLink:
-            logger.warning(f"Broken link at {path} to {value}")
+            logger.warning(f"Broken link at {path} to {value}.")
         elif log_type == ValidationProblem.FailedNamefitting:
             logger.warning(f"Found no namefit of {path} in {value}.")
         elif log_type == ValidationProblem.NXdataMissingSignalData:

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -467,6 +467,13 @@ def validate_dict_against(
                         ValidationProblem.ExpectedGroup,
                         None,
                     )
+                    # TODO: decide if we want to remove such keys
+                    # collector.collect_and_log(
+                    #     variant_path,
+                    #     ValidationProblem.KeyToBeRemoved,
+                    #     node.type,
+                    # )
+                    # keys_to_remove.append(not_visited_key)
                 continue
             if node.nx_class == "NXdata":
                 handle_nxdata(node, keys[variant], prev_path=variant_path)
@@ -497,8 +504,6 @@ def validate_dict_against(
                 May be None or a non-dict value, in which case it's returned as-is.
             prev_path (str): The path leading up to the current `keys` context, used
                 for logging and error reporting.
-            p (bool, optional): Unused parameter (possibly for debugging); included
-                for interface compatibility. Defaults to False.
 
         Returns:
             Optional[Any]: A dictionary with resolved links, the original value if
@@ -510,7 +515,9 @@ def validate_dict_against(
         if not isinstance(keys, dict):
             return keys
 
-        resolved_keys = keys
+        import copy
+
+        resolved_keys = copy.deepcopy(keys)
         for key, value in keys.copy().items():
             if isinstance(value, dict) and len(value) == 1 and "link" in value:
                 key_path = f"{prev_path}/{key}" if prev_path else key
@@ -561,6 +568,13 @@ def validate_dict_against(
                     ValidationProblem.ExpectedField,
                     None,
                 )
+                # TODO: decide if we want to remove such keys
+                # collector.collect_and_log(
+                #     variant_path,
+                #     ValidationProblem.KeyToBeRemoved,
+                #     node.type,
+                # )
+                # keys_to_remove.append(variant_path)
                 continue
             if node.optionality == "required" and isinstance(keys[variant], Mapping):
                 # Check if all fields in the dict are actual attributes (startswith @)
@@ -713,13 +727,13 @@ def validate_dict_against(
         except TypeError:
             node = None
             nx_type = "attribute" if key.split("/")[-1].startswith("@") else "field"
-            keys_to_remove.append(key)
 
             collector.collect_and_log(
                 key,
                 ValidationProblem.KeyToBeRemoved,
                 nx_type,
             )
+            keys_to_remove.append(key)
 
         if node is None:
             key_path = key.replace("@", "")
@@ -752,12 +766,13 @@ def validate_dict_against(
                     ValidationProblem.ExpectedGroup,
                     None,
                 )
+                # TODO: decide if we want to remove such keys (and below)
                 # collector.collect_and_log(
                 #     key,
                 #     ValidationProblem.KeyToBeRemoved,
                 #     "group",
                 # )
-                keys_to_remove.append(key)
+                # keys_to_remove.append(key)
                 return False
 
             elif node.type == "field":
@@ -770,13 +785,14 @@ def validate_dict_against(
                         ValidationProblem.ExpectedField,
                         None,
                     )
+                    # TODO: decide if we want to remove such keys (and below)
                     # collector.collect_and_log(
                     #     key,
                     #     ValidationProblem.KeyToBeRemoved,
                     #     "field",
                     # )
-                    keys_to_remove.append(key)
-                    return False
+                    # keys_to_remove.append(key)
+                    # return False
                 resolved_link[key] = is_valid_data_field(
                     resolved_link[key], node.dtype, node.items, node.open_enum, key
                 )

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -760,11 +760,11 @@ def validate_dict_against(
                 keys_to_remove.append(key)
                 return False
 
-            elif node.type == "field" and not all(
-                k.startswith("@") for k in resolved_link[key]
-            ):
+            elif node.type == "field":
                 # Field should only have values.
-                if is_mapping:
+                if is_mapping and not all(
+                    k.startswith("@") for k in resolved_link[key]
+                ):
                     collector.collect_and_log(
                         key,
                         ValidationProblem.ExpectedField,

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -484,6 +484,26 @@ def validate_dict_against(
     def _follow_link(
         keys: Optional[Mapping[str, Any]], prev_path: str, p=False
     ) -> Optional[Any]:
+        """
+        Resolves internal dictionary "links" by replacing any keys containing a
+        {"link": "/path/to/target"} structure with the actual referenced content.
+
+        This function traverses the mapping and recursively resolves any keys that
+        contain a "link" to another path (relative to the global template).
+        If the link cannot be resolved, the issue is logged.
+
+        Args:
+            keys (Optional[Mapping[str, Any]]): The dictionary structure to process.
+                May be None or a non-dict value, in which case it's returned as-is.
+            prev_path (str): The path leading up to the current `keys` context, used
+                for logging and error reporting.
+            p (bool, optional): Unused parameter (possibly for debugging); included
+                for interface compatibility. Defaults to False.
+
+        Returns:
+            Optional[Any]: A dictionary with resolved links, the original value if
+            `keys` is not a dict, or None if `keys` is None.
+        """
         if keys is None:
             return None
 

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -227,7 +227,7 @@ def best_namefit_of(
 
 def validate_dict_against(
     appdef: str, mapping: MutableMapping[str, Any], ignore_undocumented: bool = False
-) -> Tuple[bool, List]:
+) -> bool:
     """
     Validates a mapping against the NeXus tree for application definition `appdef`.
 
@@ -244,7 +244,6 @@ def validate_dict_against(
 
     Returns:
         bool: True if the mapping is valid according to `appdef`, False otherwise.
-        List: list of keys in mapping that correspond to attributes of non-existing fields
     """
 
     def get_variations_of(node: NexusNode, keys: Mapping[str, Any]) -> List[str]:
@@ -416,6 +415,7 @@ def validate_dict_against(
             for x in keys
             if x not in [signal, *axes, *indices, *errors, *aux_signals]
         }
+        remaining_keys = _follow_link(remaining_keys, prev_path)
         recurse_tree(
             node,
             remaining_keys,
@@ -455,6 +455,7 @@ def validate_dict_against(
             return
 
         for variant in variants:
+            variant_path = f"{prev_path}/{variant}"
             if variant in [node.name for node in node.parent_of]:
                 # Don't process if this is actually a sub-variant of this group
                 continue
@@ -462,17 +463,18 @@ def validate_dict_against(
             if not isinstance(keys[variant], Mapping):
                 if nx_class is not None:
                     collector.collect_and_log(
-                        f"{prev_path}/{variant}",
+                        variant_path,
                         ValidationProblem.ExpectedGroup,
                         None,
                     )
                 continue
             if node.nx_class == "NXdata":
-                handle_nxdata(node, keys[variant], prev_path=f"{prev_path}/{variant}")
+                handle_nxdata(node, keys[variant], prev_path=variant_path)
             if node.nx_class == "NXcollection":
                 return
             else:
-                recurse_tree(node, keys[variant], prev_path=f"{prev_path}/{variant}")
+                variant_keys = _follow_link(keys[variant], variant_path)
+                recurse_tree(node, variant_keys, prev_path=variant_path)
 
     def remove_from_not_visited(path: str) -> str:
         if path in not_visited:
@@ -480,28 +482,42 @@ def validate_dict_against(
         return path
 
     def _follow_link(
-        keys: Optional[Mapping[str, Any]], prev_path: str
+        keys: Optional[Mapping[str, Any]], prev_path: str, p=False
     ) -> Optional[Any]:
         if keys is None:
             return None
-        if len(keys) == 1 and "link" in keys:
-            current_keys = nested_keys
-            link_key = None
-            for path_elem in keys["link"][1:].split("/"):
+
+        if not isinstance(keys, dict):
+            return keys
+
+        resolved_keys = keys
+        for key, value in keys.copy().items():
+            if isinstance(value, dict) and len(value) == 1 and "link" in value:
+                key_path = f"{prev_path}/{key}" if prev_path else key
+                current_keys = nested_keys
                 link_key = None
-                for dict_path_elem in current_keys:
-                    _, hdf_name = split_class_and_name_of(dict_path_elem)
-                    if hdf_name == path_elem:
-                        link_key = hdf_name
-                        break
+                for path_elem in value["link"][1:].split("/"):
+                    link_key = None
+                    for dict_path_elem in current_keys:
+                        _, hdf_name = split_class_and_name_of(dict_path_elem)
+                        if hdf_name == path_elem:
+                            link_key = hdf_name
+                            current_keys = current_keys[dict_path_elem]
+                            break
+
                 if link_key is None:
                     collector.collect_and_log(
-                        prev_path, ValidationProblem.BrokenLink, keys["link"]
+                        key_path, ValidationProblem.BrokenLink, value["link"]
                     )
-                    return None
-                current_keys = current_keys[dict_path_elem]
-            return current_keys
-        return keys
+                    collector.collect_and_log(
+                        key_path,
+                        ValidationProblem.KeyToBeRemoved,
+                        "key",
+                    )
+                    del resolved_keys[key]
+                else:
+                    resolved_keys[key] = current_keys
+        return resolved_keys
 
     def handle_field(node: NexusNode, keys: Mapping[str, Any], prev_path: str):
         full_path = remove_from_not_visited(f"{prev_path}/{node.name}")
@@ -515,6 +531,17 @@ def validate_dict_against(
             return
 
         for variant in variants:
+            variant_path = f"{prev_path}/{variant}"
+
+            if isinstance(keys[variant], Mapping) and not all(
+                k.startswith("@") for k in keys[variant]
+            ):
+                collector.collect_and_log(
+                    variant_path,
+                    ValidationProblem.ExpectedField,
+                    None,
+                )
+                continue
             if node.optionality == "required" and isinstance(keys[variant], Mapping):
                 # Check if all fields in the dict are actual attributes (startswith @)
                 all_attrs = True
@@ -524,44 +551,47 @@ def validate_dict_against(
                         break
                 if all_attrs:
                     collector.collect_and_log(
-                        f"{prev_path}/{variant}", missing_type_err.get(node.type), None
+                        variant_path, missing_type_err.get(node.type), None
                     )
                     collector.collect_and_log(
-                        f"{prev_path}/{variant}",
+                        variant_path,
                         ValidationProblem.AttributeForNonExistingField,
                         None,
                     )
                     return
-            if variant not in keys or mapping.get(f"{prev_path}/{variant}") is None:
+            if variant not in keys or mapping.get(variant_path) is None:
                 continue
 
             # Check general validity
-            mapping[f"{prev_path}/{variant}"] = is_valid_data_field(
-                mapping[f"{prev_path}/{variant}"],
+            mapping[variant_path] = is_valid_data_field(
+                mapping[variant_path],
                 node.dtype,
                 node.items,
                 node.open_enum,
-                f"{prev_path}/{variant}",
+                variant_path,
             )
 
-            _ = check_reserved_suffix(f"{prev_path}/{variant}", mapping)
-            _ = check_reserved_prefix(f"{prev_path}/{variant}", mapping, "field")
+            _ = check_reserved_suffix(variant_path, mapping)
+            _ = check_reserved_prefix(variant_path, mapping, "field")
 
             # Check unit category
             if node.unit is not None:
                 remove_from_not_visited(f"{prev_path}/{variant}/@units")
                 if f"{variant}@units" not in keys:
                     collector.collect_and_log(
-                        f"{prev_path}/{variant}",
+                        variant_path,
                         ValidationProblem.MissingUnit,
                         node.unit,
                     )
                 # TODO: Check unit with pint
 
+            field_attributes = get_field_attributes(variant, keys)
+            field_attributes = _follow_link(field_attributes, variant_path)
+
             recurse_tree(
                 node,
-                get_field_attributes(variant, keys),
-                prev_path=f"{prev_path}/{variant}",
+                field_attributes,
+                prev_path=variant_path,
             )
 
     def handle_attribute(node: NexusNode, keys: Mapping[str, Any], prev_path: str):
@@ -577,18 +607,19 @@ def validate_dict_against(
             return
 
         for variant in variants:
-            mapping[
+            variant_path = (
                 f"{prev_path}/{variant if variant.startswith('@') else f'@{variant}'}"
-            ] = is_valid_data_field(
+            )
+            mapping[variant_path] = is_valid_data_field(
                 mapping[
                     f"{prev_path}/{variant if variant.startswith('@') else f'@{variant}'}"
                 ],
                 node.dtype,
                 node.items,
                 node.open_enum,
-                f"{prev_path}/{variant if variant.startswith('@') else f'@{variant}'}",
+                variant_path,
             )
-            _ = check_reserved_prefix(f"{prev_path}/{variant}", mapping, "attribute")
+            _ = check_reserved_prefix(variant_path, mapping, "attribute")
 
     def handle_choice(node: NexusNode, keys: Mapping[str, Any], prev_path: str):
         global collector
@@ -690,7 +721,46 @@ def validate_dict_against(
             return True
 
         if isinstance(mapping[key], dict) and "link" in mapping[key]:
-            # TODO: Follow link and check consistency with current field
+            resolved_link = _follow_link({key: mapping[key]}, "")
+
+            is_mapping = isinstance(resolved_link[key], Mapping)
+
+            if node.type == "group" and not is_mapping:
+                # Groups must have subelements
+                collector.collect_and_log(
+                    key,
+                    ValidationProblem.ExpectedGroup,
+                    None,
+                )
+                # collector.collect_and_log(
+                #     key,
+                #     ValidationProblem.KeyToBeRemoved,
+                #     "group",
+                # )
+                keys_to_remove.append(key)
+                return False
+
+            elif node.type == "field" and not all(
+                k.startswith("@") for k in resolved_link[key]
+            ):
+                # Field should only have values.
+                if is_mapping:
+                    collector.collect_and_log(
+                        key,
+                        ValidationProblem.ExpectedField,
+                        None,
+                    )
+                    # collector.collect_and_log(
+                    #     key,
+                    #     ValidationProblem.KeyToBeRemoved,
+                    #     "field",
+                    # )
+                    keys_to_remove.append(key)
+                    return False
+                resolved_link[key] = is_valid_data_field(
+                    resolved_link[key], node.dtype, node.items, node.open_enum, key
+                )
+
             return True
 
         if "@" not in key and node.type != "field":
@@ -727,7 +797,6 @@ def validate_dict_against(
         for child in node.children:
             if ignore_names is not None and child.name in ignore_names:
                 continue
-            keys = _follow_link(keys, prev_path)
             if keys is None:
                 return
 
@@ -735,23 +804,18 @@ def validate_dict_against(
 
     def check_attributes_of_nonexisting_field(
         node: NexusNode,
-    ) -> list:
+    ):
         """
             This method runs through the mapping dictionary and checks if there are any
             attributes assigned to the fields (not groups!) which are not explicitly
             present in the mapping.
             If there are any found, a warning is logged and the corresponding items are
-            added to the list returned by the method.
+            added to the list that stores all keys that shall be removed.
 
         Args:
             node (NexusNode): the tree generated from application definition.
 
-        Returns:
-            list: list of keys in mapping that correspond to attributes of
-            non-existing fields
         """
-
-        keys_to_remove = []
 
         for key in mapping:
             last_index = key.rfind("/")
@@ -795,14 +859,8 @@ def validate_dict_against(
                         collector.collect_and_log(
                             key[0:last_index],
                             ValidationProblem.AttributeForNonExistingField,
-                            None,
-                        )
-                        collector.collect_and_log(
-                            key,
-                            ValidationProblem.KeyToBeRemoved,
                             "attribute",
                         )
-        return keys_to_remove
 
     def check_type_with_tree(
         node: NexusNode,
@@ -1062,13 +1120,16 @@ def validate_dict_against(
         "choice": handle_choice,
     }
 
+    keys_to_remove = []
+
     tree = generate_tree_from(appdef)
     collector.clear()
     nested_keys = build_nested_dict_from(mapping)
     not_visited = list(mapping)
+    keys = _follow_link(nested_keys, "")
     recurse_tree(tree, nested_keys)
 
-    keys_to_remove = check_attributes_of_nonexisting_field(tree)
+    check_attributes_of_nonexisting_field(tree)
 
     for not_visited_key in not_visited:
         # TODO: remove again if "@target"/"@reference" is sorted out by NIAC
@@ -1160,7 +1221,11 @@ def validate_dict_against(
     # clear lru_cache
     NexusNode.search_add_child_for.cache_clear()
 
-    return (not collector.has_validation_problems(), keys_to_remove)
+    # remove keys that are incorrect
+    for key in set(keys_to_remove):
+        del mapping[key]
+
+    return not collector.has_validation_problems()
 
 
 def populate_full_tree(node: NexusNode, max_depth: Optional[int] = 5, depth: int = 0):
@@ -1194,4 +1259,4 @@ def populate_full_tree(node: NexusNode, max_depth: Optional[int] = 5, depth: int
 def validate_data_dict(
     _: MutableMapping[str, Any], read_data: MutableMapping[str, Any], root: ET._Element
 ) -> bool:
-    return validate_dict_against(root.attrib["name"], read_data)[0]
+    return validate_dict_against(root.attrib["name"], read_data)

--- a/src/pynxtools/dataconverter/writer.py
+++ b/src/pynxtools/dataconverter/writer.py
@@ -250,7 +250,12 @@ class Writer:
             attrs = self.__nxdl_to_attrs(parent_path)
 
             if attrs is not None:
-                grp.attrs["NX_class"] = attrs["type"]
+                if nx_class := attrs.get("type"):
+                    grp.attrs["NX_class"] = nx_class
+                else:
+                    logger.error(
+                        f"No attribute 'NX_class' could be written for {parent_path}."
+                    )
             return grp
         return self.output_nexus[parent_path_hdf5]
 

--- a/tests/dataconverter/test_readers.py
+++ b/tests/dataconverter/test_readers.py
@@ -117,6 +117,6 @@ def test_has_correct_read_func(reader, caplog):
                 with caplog.at_level(logging.WARNING):
                     validate_dict_against(
                         supported_nxdl, read_data, ignore_undocumented=True
-                    )[0]
+                    )
 
                 print(caplog.text)

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -846,6 +846,7 @@ TEMPLATE["required"][
             [
                 "Expected a field at /ENTRY[my_entry]/OPTIONAL_group[some_group]/required_field but found a group.",
                 "Expected a group at /ENTRY[my_entry]/USER[my_user] but found a field or attribute.",
+                "Field /ENTRY[my_entry]/USER[my_user] written without documentation.",
             ],
             id="appdef-links-with-wrong-nexus-types",
         ),
@@ -874,6 +875,7 @@ TEMPLATE["required"][
             ),
             [
                 "Expected a group at /ENTRY[my_entry]/SAMPLE[my_sample] but found a field or attribute.",
+                "Field /ENTRY[my_entry]/SAMPLE[my_sample] written without documentation.",
                 "Expected a field at /ENTRY[my_entry]/SAMPLE[my_sample]/name but found a group.",
             ],
             id="base-class-links-with-wrong-nexus-types",

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -837,6 +837,19 @@ TEMPLATE["required"][
                 alter_dict(
                     TEMPLATE,
                     "/ENTRY[my_entry]/SAMPLE[my_sample]",
+                    {"link": "/my_entry/my_group"},
+                ),
+                "/ENTRY[my_entry]/SAMPLE[my_sample]/name",
+                {"link": "/my_entry/nxodd_name/char_value"},
+            ),
+            [],
+            id="base-class-links-with-matching-nexus-types",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    TEMPLATE,
+                    "/ENTRY[my_entry]/SAMPLE[my_sample]",
                     {"link": "/my_entry/my_group/required_field"},
                 ),
                 "/ENTRY[my_entry]/SAMPLE[my_sample]/name",

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -819,6 +819,23 @@ TEMPLATE["required"][
         pytest.param(
             alter_dict(
                 alter_dict(
+                    remove_from_dict(
+                        TEMPLATE,
+                        "/ENTRY[my_entry]/required_group/description",
+                        "optional",
+                    ),
+                    "/ENTRY[my_entry]/required_group",
+                    {"link": "/my_entry/required_group2"},
+                ),
+                "/ENTRY[my_entry]/OPTIONAL_group[some_group]/required_field",
+                {"link": "/my_entry/specified_group/specified_field"},
+            ),
+            [],
+            id="appdef-links-with-matching-nexus-types",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
                     TEMPLATE,
                     "/ENTRY[my_entry]/USER[my_user]",
                     {"link": "/my_entry/my_group/required_field"},


### PR DESCRIPTION
@rettigl with this PR, we properly follow links as discussed in https://github.com/FAIRmat-NFDI/pynxtools/pull/638#issuecomment-2891469373 and raise an error if the type of the key does not match the type of the linked entity. This works both for concepts from appdefs as well as from base classes (see the two new tests).

I had to make a lot of changes on the way unfortunately, hence this new PR (pointing to my previous one):
- Link following was completely changed. Before, we could only follow if a single field within a group was linked, but already a structure like 
  ```
  "/ENTRY[my_entry]/OPTIONAL_group[some_group]/required_field": {"link": ..."},
  "/ENTRY[my_entry]/OPTIONAL_group[some_group]/optional_field": 1.0,
  ```
  could not be resolved.
- Now also following links when we check in the `is_documented` part for concepts from the base classes.

Further improvements:
- ValidationProblems are auto-enumerated (meaning we can add new ones anywhere)
- Keys to removed are stored along the way and then removed directly in the `validate_data_dict` function (so we don't have to pass them to the converter) -> `validate_dict_against` just returns a boolean, as before.

Questions:
- Can you double check that your initial use case works now?
- Do we want to remove keys where the type of the linked entity doesn't match?
- More broadly, do we want to remove fields/groups if they lead to `ExpectedGroup/ExpectedField` errors?