### PR TITLE
Error for multiple different variadic concepts with the same name

### DIFF
--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -88,7 +88,7 @@ class Collector:
 
         if log_type == ValidationProblem.DifferentVariadicNodesWithTheSameName:
             value = cast(Any, value)
-            logger.error(
+            logger.warning(
                 f"Instance name '{path}' used for multiple different concepts: "
                 f"{', '.join(sorted(set(c for c, _ in value)))}. "
                 f"The following keys are affected: {', '.join(sorted(set(k for _, k in value)))}."

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -73,6 +73,7 @@ class ValidationProblem(Enum):
     ReservedSuffixWithoutField = auto()
     ReservedPrefixInWrongContext = auto()
     InvalidNexusTypeForNamedConcept = auto()
+    KeysWithAndWithoutConcept = auto()
 
 
 class Collector:
@@ -184,6 +185,11 @@ class Collector:
             logger.error(
                 f"The type ('{args[0] if args else '<unknown>'}') of the given concept '{path}' "
                 f"conflicts with another existing concept of the same name, which is of type '{value.type}'."
+            )
+        elif log_type == ValidationProblem.KeysWithAndWithoutConcept:
+            value = cast(Any, value)
+            logger.warning(
+                f"The key '{path}' uses the valid concept name '{args[0]}', but there is another valid key {value} that uses the non-variadic name of the node.'"
             )
 
     def collect_and_log(

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -46,6 +46,7 @@ logger = logging.getLogger("pynxtools")
 
 
 class ValidationProblem(Enum):
+    DifferentVariadicNodesWithTheSameName = auto()
     UnitWithoutDocumentation = auto()
     InvalidEnum = auto()
     OpenEnumWithNewItem = auto()
@@ -85,6 +86,13 @@ class Collector:
         if value is None:
             value = "<unknown>"
 
+        if log_type == ValidationProblem.DifferentVariadicNodesWithTheSameName:
+            value = cast(Any, value)
+            logger.error(
+                f"Instance name '{path}' used for multiple different concepts: "
+                f"{', '.join(sorted(set(c for c, _ in value)))}. "
+                f"The following keys are affected: {', '.join(sorted(set(k for _, k in value)))}."
+            )
         if log_type == ValidationProblem.UnitWithoutDocumentation:
             logger.info(
                 f"The unit, {path} = {value}, is being written but has no documentation."

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -898,6 +898,30 @@ def validate_dict_against(
 
                 # Determine the parent path up to just before this match
                 parent_path = key[: match.start()]
+                child_path = key[match.start() :].split("/", 1)[-1]
+
+                # Here we check if for this key with a concept name, another valid key
+                # with a non-concept name exists.
+                non_concept_key = f"{parent_path}{instance_name}/{child_path}"
+
+                if non_concept_key in mapping:
+                    try:
+                        node = add_best_matches_for(non_concept_key, tree)
+                        if node is not None:
+                            collector.collect_and_log(
+                                key,
+                                ValidationProblem.KeysWithAndWithoutConcept,
+                                non_concept_key,
+                                concept_name,
+                            )
+                            collector.collect_and_log(
+                                key, ValidationProblem.KeyToBeRemoved, "key"
+                            )
+                            keys_to_remove.append(key)
+                            continue
+                    except TypeError:
+                        pass
+
                 instance_usage[(instance_name, parent_path)].append((concept_name, key))
 
         for (instance_name, parent_path), entries in sorted(instance_usage.items()):

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -912,7 +912,7 @@ def validate_dict_against(
                     entries,
                 )
                 # Now that we have name conflicts, we still need to check that there are
-                # at least two valid keys in that conclit. Only then we remove these.
+                # at least two valid keys in that conflict. Only then we remove these.
                 # This takes care of the example with keys like
                 # /ENTRY[my_entry]/USER[some_name]/name and /ENTRY[my_entry]/USERS[some_name]/name,
                 #  where we only want to keep the first one.

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -874,7 +874,7 @@ def validate_dict_against(
         and the conflicting concept names. Additionally, all keys involved in the conflict
         are logged and added to the `keys_to_remove` list.
 
-        Parameters:
+        Args:
             mapping (MutableMapping[str, str]):
                 The mapping containing the data to validate.
                 This should be a dict of `/` separated paths, such as

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -891,6 +891,9 @@ def validate_dict_against(
 
         for key in mapping:
             matches = list(pattern.finditer(key))
+            if not matches:
+                # The keys contains no concepts with variable name, no need to further check
+                continue
             for match in matches:
                 concept_name = match.group("concept_name")
                 instance_name = match.group("instance")

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -891,7 +891,7 @@ def validate_dict_against(
 
         for key in mapping:
             matches = list(pattern.finditer(key))
-            for i, match in enumerate(matches):
+            for match in matches:
                 concept_name = match.group("concept_name")
                 instance_name = match.group("instance")
 

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -850,9 +850,7 @@ def validate_dict_against(
 
             handling_map.get(child.type, handle_unknown_type)(child, keys, prev_path)
 
-    def find_instance_name_conflicts(
-        mapping: MutableMapping[str, str], keys_to_remove: List[str]
-    ) -> None:
+    def find_instance_name_conflicts(mapping: MutableMapping[str, str]) -> None:
         """
         Detect and log conflicts where the same variadic instance name is reused across
         different concept names.
@@ -1266,7 +1264,7 @@ def validate_dict_against(
 
     tree = generate_tree_from(appdef)
     collector.clear()
-    find_instance_name_conflicts(mapping, keys_to_remove)
+    find_instance_name_conflicts(mapping)
     nested_keys = build_nested_dict_from(mapping)
     not_visited = list(mapping)
     keys = _follow_link(nested_keys, "")

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -258,7 +258,7 @@ TEMPLATE["required"][
                     "Another sample name",
                 ),
                 "/ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name",
-                "Another c name within an instrument.",
+                "Another aperture name within an instrument.",
             ),
             [
                 "Instance name 'another_name' used for multiple different concepts: APERTURE, SAMPLE. "

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -240,52 +240,118 @@ TEMPLATE["required"][
                     alter_dict(
                         alter_dict(
                             alter_dict(
-                                alter_dict(
-                                    alter_dict(
-                                        alter_dict(
-                                            TEMPLATE,
-                                            "/ENTRY[my_entry]/SAMPLE[some_name]/name",
-                                            "A sample name",
-                                        ),
-                                        "/ENTRY[my_entry]/USER[some_name]/name",
-                                        "A user name",
-                                    ),
-                                    "/ENTRY[my_entry]/MONITOR[some_name]/name",
-                                    "An monitor name",
-                                ),
-                                "/ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name",
-                                "An aperture within an instrument",
+                                TEMPLATE,
+                                "/ENTRY[my_entry]/SAMPLE[some_name]/name",
+                                "A sample name",
                             ),
-                            "/ENTRY[my_entry]/INSTRUMENT[instrument]/DETECTOR[another_name]/name",
-                            "A detector within an instrument",
+                            "/ENTRY[my_entry]/SAMPLE[some_name]/description",
+                            "A sample description",
                         ),
-                        "/ENTRY[my_entry]/INSTRUMENT[instrument]/SOURCE[my_source]/APERTURE[another_name]/name",
-                        "An aperture within a source inside an instrument",
+                        "/ENTRY[my_entry]/USER[some_name]/name",
+                        "A user name",
                     ),
-                    "/ENTRY[my_entry]/USER[a_third_name]/name",
-                    "A tird user name",
+                    "/ENTRY[my_entry]/MONITOR[some_name]/name",
+                    "A monitor name",
                 ),
-                "/ENTRY[my_entry]/USERS[a_third_name]/name",
-                "An invalid group of the same name",
+                "/ENTRY[my_entry]/MONITOR[some_name]/description",
+                "A monitor description",
             ),
             [
-                "Instance name 'a_third_name' used for multiple different concepts: USER, USERS. "
-                "The following keys are affected: /ENTRY[my_entry]/USERS[a_third_name]/name, "
-                "/ENTRY[my_entry]/USER[a_third_name]/name.",
-                "The key /ENTRY[my_entry]/USERS[a_third_name]/name will not be written.",
+                "Instance name 'some_name' used for multiple different concepts: MONITOR, SAMPLE, USER. "
+                "The following keys are affected: /ENTRY[my_entry]/MONITOR[some_name]/description, "
+                "/ENTRY[my_entry]/MONITOR[some_name]/name, /ENTRY[my_entry]/SAMPLE[some_name]/description, "
+                "/ENTRY[my_entry]/SAMPLE[some_name]/name, /ENTRY[my_entry]/USER[some_name]/name.",
+                "The key /ENTRY[my_entry]/MONITOR[some_name]/description will not be written.",
+                "The key /ENTRY[my_entry]/MONITOR[some_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/SAMPLE[some_name]/description will not be written.",
+                "The key /ENTRY[my_entry]/SAMPLE[some_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/USER[some_name]/name will not be written.",
+            ],
+            id="variadic-groups-of-the-same-name",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    alter_dict(
+                        TEMPLATE,
+                        "/ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name",
+                        "An aperture within an instrument",
+                    ),
+                    "/ENTRY[my_entry]/INSTRUMENT[instrument]/DETECTOR[another_name]/name",
+                    "A detector within an instrument",
+                ),
+                "/ENTRY[my_entry]/INSTRUMENT[instrument]/SOURCE[my_source]/APERTURE[another_name]/name",
+                "An aperture within a source inside an instrument",
+            ),
+            [
                 "Instance name 'another_name' used for multiple different concepts: APERTURE, DETECTOR. "
                 "The following keys are affected: /ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name, "
                 "/ENTRY[my_entry]/INSTRUMENT[instrument]/DETECTOR[another_name]/name.",
                 "The key /ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name will not be written.",
                 "The key /ENTRY[my_entry]/INSTRUMENT[instrument]/DETECTOR[another_name]/name will not be written.",
-                "Instance name 'some_name' used for multiple different concepts: MONITOR, SAMPLE, USER. "
-                "The following keys are affected: /ENTRY[my_entry]/MONITOR[some_name]/name, "
-                "/ENTRY[my_entry]/SAMPLE[some_name]/name, /ENTRY[my_entry]/USER[some_name]/name.",
-                "The key /ENTRY[my_entry]/MONITOR[some_name]/name will not be written.",
-                "The key /ENTRY[my_entry]/SAMPLE[some_name]/name will not be written.",
-                "The key /ENTRY[my_entry]/USER[some_name]/name will not be written.",
             ],
-            id="variadic-groups-of-the-same-name",
+            id="variadic-groups-of-the-same-name-but-at-different-levels",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    alter_dict(
+                        alter_dict(
+                            alter_dict(
+                                alter_dict(
+                                    TEMPLATE,
+                                    "/ENTRY[my_entry]/USER[user]/name",
+                                    "A user name",
+                                ),
+                                "/ENTRY[my_entry]/USER[user]/role",
+                                "A user role",
+                            ),
+                            "/ENTRY[my_entry]/USER[user]/affiliation",
+                            "A user affiliation",
+                        ),
+                        "/ENTRY[my_entry]/ILLEGAL[user]/name",
+                        "An illegal user name",
+                    ),
+                    "/ENTRY[my_entry]/ILLEGAL[user]/role",
+                    "An illegal user role",
+                ),
+                "/ENTRY[my_entry]/ILLEGAL[user]/affiliation",
+                "An illegal user affiliation",
+            ),
+            [
+                "Instance name 'user' used for multiple different concepts: ILLEGAL, USER. "
+                "The following keys are affected: /ENTRY[my_entry]/ILLEGAL[user]/affiliation, /ENTRY[my_entry]/ILLEGAL[user]/name, "
+                "/ENTRY[my_entry]/ILLEGAL[user]/role, /ENTRY[my_entry]/USER[user]/affiliation, /ENTRY[my_entry]/USER[user]/name, "
+                "/ENTRY[my_entry]/USER[user]/role.",
+                "The key /ENTRY[my_entry]/ILLEGAL[user]/affiliation will not be written.",
+                "The key /ENTRY[my_entry]/ILLEGAL[user]/name will not be written.",
+                "The key /ENTRY[my_entry]/ILLEGAL[user]/role will not be written.",
+            ],
+            id="variadic-groups-of-the-same-name-illegal-concept-multiple-fields",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    alter_dict(
+                        TEMPLATE,
+                        "/ENTRY[my_entry]/USER[user]/name",
+                        "A user name",
+                    ),
+                    "/ENTRY[my_entry]/USERS[user]/name",
+                    "An invalid group of the same name",
+                ),
+                "/ENTRY[my_entry]/SAMPLE[user]/name",
+                "A sample group called user with a name",
+            ),
+            [
+                "Instance name 'user' used for multiple different concepts: SAMPLE, USER, USERS. "
+                "The following keys are affected: /ENTRY[my_entry]/SAMPLE[user]/name, "
+                "/ENTRY[my_entry]/USERS[user]/name, /ENTRY[my_entry]/USER[user]/name.",
+                "The key /ENTRY[my_entry]/USERS[user]/name will not be written.",
+                "The key /ENTRY[my_entry]/SAMPLE[user]/name will not be written.",
+                "The key /ENTRY[my_entry]/USER[user]/name will not be written.",
+            ],
+            id="variadic-groups-of-the-same-name-mix-of-valid-and-illegal-concepts",
         ),
         pytest.param(
             alter_dict(

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -238,6 +238,43 @@ TEMPLATE["required"][
             alter_dict(
                 alter_dict(
                     alter_dict(
+                        alter_dict(
+                            alter_dict(
+                                TEMPLATE,
+                                "/ENTRY[my_entry]/SAMPLE[some_name]/name",
+                                "A sample name",
+                            ),
+                            "/ENTRY[my_entry]/USER[some_name]/name",
+                            "A user name",
+                        ),
+                        "/ENTRY[my_entry]/MONITOR[some_name]/name",
+                        "A monitor name",
+                    ),
+                    "/ENTRY[my_entry]/MONITOR[another_name]/name",
+                    "Another monitor name",
+                ),
+                "/ENTRY[my_entry]/SAMPLE[another_name]/name",
+                "Another sample name",
+            ),
+            [
+                "Instance name 'another_name' used for multiple different concepts: MONITOR, SAMPLE. "
+                "The following keys are affected: /ENTRY[my_entry]/MONITOR[another_name]/name, "
+                "/ENTRY[my_entry]/SAMPLE[another_name]/name.",
+                "The key /ENTRY[my_entry]/MONITOR[another_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/SAMPLE[another_name]/name will not be written.",
+                "Instance name 'some_name' used for multiple different concepts: MONITOR, SAMPLE, USER. "
+                "The following keys are affected: /ENTRY[my_entry]/MONITOR[some_name]/name, "
+                "/ENTRY[my_entry]/SAMPLE[some_name]/name, /ENTRY[my_entry]/USER[some_name]/name.",
+                "The key /ENTRY[my_entry]/MONITOR[some_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/SAMPLE[some_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/USER[some_name]/name will not be written.",
+            ],
+            id="variadic-groups-of-the-same-name",
+        ),
+        pytest.param(
+            alter_dict(
+                alter_dict(
+                    alter_dict(
                         remove_from_dict(
                             remove_from_dict(
                                 remove_from_dict(

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -241,35 +241,47 @@ TEMPLATE["required"][
                         alter_dict(
                             alter_dict(
                                 alter_dict(
-                                    TEMPLATE,
-                                    "/ENTRY[my_entry]/SAMPLE[some_name]/name",
-                                    "A sample name",
+                                    alter_dict(
+                                        alter_dict(
+                                            TEMPLATE,
+                                            "/ENTRY[my_entry]/SAMPLE[some_name]/name",
+                                            "A sample name",
+                                        ),
+                                        "/ENTRY[my_entry]/USER[some_name]/name",
+                                        "A user name",
+                                    ),
+                                    "/ENTRY[my_entry]/MONITOR[some_name]/name",
+                                    "An monitor name",
                                 ),
-                                "/ENTRY[my_entry]/USER[some_name]/name",
-                                "A user name",
+                                "/ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name",
+                                "An aperture within an instrument",
                             ),
-                            "/ENTRY[my_entry]/APERTURE[some_name]/name",
-                            "An monitor name",
+                            "/ENTRY[my_entry]/INSTRUMENT[instrument]/DETECTOR[another_name]/name",
+                            "A detector within an instrument",
                         ),
-                        "/ENTRY[my_entry]/APERTURE[another_name]/name",
-                        "Another monitor name",
+                        "/ENTRY[my_entry]/INSTRUMENT[instrument]/SOURCE[my_source]/APERTURE[another_name]/name",
+                        "An aperture within a source inside an instrument",
                     ),
-                    "/ENTRY[my_entry]/SAMPLE[another_name]/name",
-                    "Another sample name",
+                    "/ENTRY[my_entry]/USER[a_third_name]/name",
+                    "A tird user name",
                 ),
-                "/ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name",
-                "Another aperture name within an instrument.",
+                "/ENTRY[my_entry]/USERS[a_third_name]/name",
+                "An invalid group of the same name",
             ),
             [
-                "Instance name 'another_name' used for multiple different concepts: APERTURE, SAMPLE. "
-                "The following keys are affected: /ENTRY[my_entry]/APERTURE[another_name]/name, "
-                "/ENTRY[my_entry]/SAMPLE[another_name]/name.",
-                "The key /ENTRY[my_entry]/APERTURE[another_name]/name will not be written.",
-                "The key /ENTRY[my_entry]/SAMPLE[another_name]/name will not be written.",
-                "Instance name 'some_name' used for multiple different concepts: APERTURE, SAMPLE, USER. "
-                "The following keys are affected: /ENTRY[my_entry]/APERTURE[some_name]/name, "
+                "Instance name 'a_third_name' used for multiple different concepts: USER, USERS. "
+                "The following keys are affected: /ENTRY[my_entry]/USERS[a_third_name]/name, "
+                "/ENTRY[my_entry]/USER[a_third_name]/name.",
+                "The key /ENTRY[my_entry]/USERS[a_third_name]/name will not be written.",
+                "Instance name 'another_name' used for multiple different concepts: APERTURE, DETECTOR. "
+                "The following keys are affected: /ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name, "
+                "/ENTRY[my_entry]/INSTRUMENT[instrument]/DETECTOR[another_name]/name.",
+                "The key /ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/INSTRUMENT[instrument]/DETECTOR[another_name]/name will not be written.",
+                "Instance name 'some_name' used for multiple different concepts: MONITOR, SAMPLE, USER. "
+                "The following keys are affected: /ENTRY[my_entry]/MONITOR[some_name]/name, "
                 "/ENTRY[my_entry]/SAMPLE[some_name]/name, /ENTRY[my_entry]/USER[some_name]/name.",
-                "The key /ENTRY[my_entry]/APERTURE[some_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/MONITOR[some_name]/name will not be written.",
                 "The key /ENTRY[my_entry]/SAMPLE[some_name]/name will not be written.",
                 "The key /ENTRY[my_entry]/USER[some_name]/name will not be written.",
             ],

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -236,6 +236,20 @@ TEMPLATE["required"][
     [
         pytest.param(
             alter_dict(
+                TEMPLATE,
+                "/ENTRY[my_entry]/NOTE[required_group2]/description",
+                "an additional description",
+            ),
+            [
+                "The key '/ENTRY[my_entry]/NOTE[required_group2]/description' uses the valid concept name 'NOTE', "
+                "but there is another valid key /ENTRY[my_entry]/required_group2/description that uses the non-variadic "
+                "name of the node.'",
+                "The key /ENTRY[my_entry]/NOTE[required_group2]/description will not be written.",
+            ],
+            id="same-concept-with-and-without-concept-name",
+        ),
+        pytest.param(
+            alter_dict(
                 alter_dict(
                     alter_dict(
                         alter_dict(

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -240,32 +240,36 @@ TEMPLATE["required"][
                     alter_dict(
                         alter_dict(
                             alter_dict(
-                                TEMPLATE,
-                                "/ENTRY[my_entry]/SAMPLE[some_name]/name",
-                                "A sample name",
+                                alter_dict(
+                                    TEMPLATE,
+                                    "/ENTRY[my_entry]/SAMPLE[some_name]/name",
+                                    "A sample name",
+                                ),
+                                "/ENTRY[my_entry]/USER[some_name]/name",
+                                "A user name",
                             ),
-                            "/ENTRY[my_entry]/USER[some_name]/name",
-                            "A user name",
+                            "/ENTRY[my_entry]/APERTURE[some_name]/name",
+                            "An monitor name",
                         ),
-                        "/ENTRY[my_entry]/MONITOR[some_name]/name",
-                        "A monitor name",
+                        "/ENTRY[my_entry]/APERTURE[another_name]/name",
+                        "Another monitor name",
                     ),
-                    "/ENTRY[my_entry]/MONITOR[another_name]/name",
-                    "Another monitor name",
+                    "/ENTRY[my_entry]/SAMPLE[another_name]/name",
+                    "Another sample name",
                 ),
-                "/ENTRY[my_entry]/SAMPLE[another_name]/name",
-                "Another sample name",
+                "/ENTRY[my_entry]/INSTRUMENT[instrument]/APERTURE[another_name]/name",
+                "Another c name within an instrument.",
             ),
             [
-                "Instance name 'another_name' used for multiple different concepts: MONITOR, SAMPLE. "
-                "The following keys are affected: /ENTRY[my_entry]/MONITOR[another_name]/name, "
+                "Instance name 'another_name' used for multiple different concepts: APERTURE, SAMPLE. "
+                "The following keys are affected: /ENTRY[my_entry]/APERTURE[another_name]/name, "
                 "/ENTRY[my_entry]/SAMPLE[another_name]/name.",
-                "The key /ENTRY[my_entry]/MONITOR[another_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/APERTURE[another_name]/name will not be written.",
                 "The key /ENTRY[my_entry]/SAMPLE[another_name]/name will not be written.",
-                "Instance name 'some_name' used for multiple different concepts: MONITOR, SAMPLE, USER. "
-                "The following keys are affected: /ENTRY[my_entry]/MONITOR[some_name]/name, "
+                "Instance name 'some_name' used for multiple different concepts: APERTURE, SAMPLE, USER. "
+                "The following keys are affected: /ENTRY[my_entry]/APERTURE[some_name]/name, "
                 "/ENTRY[my_entry]/SAMPLE[some_name]/name, /ENTRY[my_entry]/USER[some_name]/name.",
-                "The key /ENTRY[my_entry]/MONITOR[some_name]/name will not be written.",
+                "The key /ENTRY[my_entry]/APERTURE[some_name]/name will not be written.",
                 "The key /ENTRY[my_entry]/SAMPLE[some_name]/name will not be written.",
                 "The key /ENTRY[my_entry]/USER[some_name]/name will not be written.",
             ],
@@ -1116,11 +1120,11 @@ TEMPLATE["required"][
         pytest.param(
             alter_dict(
                 TEMPLATE,
-                "/ENTRY[my_entry]/INSTRUMENT[my_instrument]/ILLEGAL[my_source]/type",
+                "/ENTRY[my_entry]/INSTRUMENT[my_instrument]/ILLEGAL[my_source2]/type",
                 1,
             ),
             [
-                "Field /ENTRY[my_entry]/INSTRUMENT[my_instrument]/ILLEGAL[my_source]/type written without documentation."
+                "Field /ENTRY[my_entry]/INSTRUMENT[my_instrument]/ILLEGAL[my_source2]/type written without documentation."
             ],
             id="bad-namefitting",
         ),


### PR DESCRIPTION
As discussed in #636 and #638, we should not allow the same instance name for two unnamed groups, e.g. `NXuser` and `NXsample`. We implement this here by running a check on the whole mapping table before any of the other validation starts. Note that we _have_ to remove such keys as they will necessarily lead to HDF5 conflicts (HDF5 depends on unique names for groups and datasets).

Error message may need some improvement, wasn't too sure how to report this issue.