### PR TITLE
add units files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,4 +11,5 @@ include src/pynxtools/definitions/*.xsd
 include src/pynxtools/nexus-version.txt
 include src/pynxtools/remote_definitions_url.txt
 include src/pynxtools/definitions/NXDL_VERSION
+include src/pynxtools/units/*.txt
 graft src/pynxtools/nomad/examples


### PR DESCRIPTION
This is needed to ship the two units .txt files when building the package.