### PR TITLE
units: support for offset units, add tests

### DIFF
--- a/src/pynxtools/units/__init__.py
+++ b/src/pynxtools/units/__init__.py
@@ -167,6 +167,6 @@ class NXUnitSet:
         if ureg.Unit(unit) == ureg.Unit("pixel") and str(expected_dim) == "[length]":
             return True
 
-        actual_dim = (1 * ureg(unit)).dimensionality
+        actual_dim = ureg.Quantity(1, unit).to_base_units().dimensionality
 
         return actual_dim == expected_dim

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pynxtools.units import NXUnitSet
+
+
+@pytest.mark.parametrize(
+    "unit_category,unit,expected",
+    [
+        ("NX_LENGTH", "meter", True),
+        ("NX_LENGTH", "m", True),
+        ("NX_LENGTH", "second", False),
+        ("NX_TEMPERATURE", "kelvin", True),
+        ("NX_TEMPERATURE", "celsius", True),  # offset unit
+        ("NX_TEMPERATURE", "degC", True),  # alias
+        ("NX_TEMPERATURE", "second", False),
+        ("NX_ANY", "meter", True),
+        ("NX_ANY", "", True),  # empty allowed
+        ("NX_ANY", "foobar", False),  # unknown unit not allowed for NX_ANY
+        ("NX_LENGTH", "foobar", False),  # unknown unit not allowed
+        ("NX_LENGTH", "pixel", True),  # pixel is accepted as length
+        ("NX_DIMENSIONLESS", "", True),
+        ("NX_DIMENSIONLESS", "meter", False),
+        ("NX_UNITLESS", "", True),
+        ("NX_UNITLESS", "meter", False),
+    ],
+)
+def test_matches(unit_category, unit, expected):
+    assert NXUnitSet.matches(unit_category, unit) == expected


### PR DESCRIPTION
This add support for units like `celsius` which are defined with an offset w.r.t a base unit (like `Kelvin`): https://github.com/FAIRmat-NFDI/pynxtools/blob/master/src/pynxtools/units/default_en.txt#L160.

I also added some test for the unit matching, but this is probaly not super comprehensive (we have some of these tests, like for `NXtransformation`, also in `test_validation.py` though).