### PR TITLE
only log nomad messages of INFO or higher in reader test framework

### DIFF
--- a/src/pynxtools/testing/nexus_conversion.py
+++ b/src/pynxtools/testing/nexus_conversion.py
@@ -22,6 +22,8 @@ import os
 from glob import glob
 from typing import Literal, Optional
 
+import structlog
+
 try:
     from nomad.client import parse
 
@@ -173,6 +175,10 @@ class ReaderTest:
                 password=None,
             )
 
+            # Set level of all structlog loggers to "INFO"
+            structlog.configure(
+                wrapper_class=structlog.make_filtering_bound_logger(logging.INFO)
+            )
             parse(self.created_nexus, **kwargs)
 
     def check_reproducibility_of_nexus(self, **kwargs):


### PR DESCRIPTION
@rettigl it is a bit hard to see here because all tests pass (which suppresses most logs), but if you run this with a test that fails from #333), the output is
```
E           AssertionError: Log files are different: mismatched line counts. Generated file has 8189 lines, while reference file has 8123 lines.
E
E           Extra lines in generated:
E           [...] # many extra lines here
E           [...]

src/pynxtools/testing/nexus_conversion.py:275: AssertionError
--------------------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------------------
Using mpes reader to convert the given files:
• /home/lukaspie/fairmat/nomad-distro-dev/packages/pynxtools-mpes/tests/data/xarray_saved_small_calibration.h5
• /home/lukaspie/fairmat/nomad-distro-dev/packages/pynxtools-mpes/tests/data/config_file.json
The output file generated: /tmp/pytest-of-lukaspie/pytest-91/test_nexus_conversion0///output.nxs.
----------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------
INFO     pynxtools:convert.py:147 Using mpes reader to convert the given files:
• /home/lukaspie/fairmat/nomad-distro-dev/packages/pynxtools-mpes/tests/data/xarray_saved_small_calibration.h5
• /home/lukaspie/fairmat/nomad-distro-dev/packages/pynxtools-mpes/tests/data/config_file.json
INFO     pynxtools:convert.py:242 The output file generated: /tmp/pytest-of-lukaspie/pytest-91/test_nexus_conversion0///output.nxs.
INFO     nomad.client:processing.py:67 {"event": "identified parser", "parser": "pynxtools.nomad.entrypoints:nexus_parser", "timestamp": "2025-08-13 17:06.13"}
INFO     nomad.client:parser.py:307 {"event": "set NaN for field of a scalar", "parser": "pynxtools.nomad.entrypoints:nexus_parser", "target_name": "size__field[size__field]", "timestamp": "2025-08-13 17:06.13"}
INFO     nomad.client:processing.py:82 {"event": "ran parser", "parser": "pynxtools.nomad.entrypoints:nexus_parser", "timestamp": "2025-08-13 17:06.15"}
```
which I think is reasonable. 