### PR TITLE
Fix error coming Operand '| None'

### DIFF
--- a/src/pynxtools/nomad/schema.py
+++ b/src/pynxtools/nomad/schema.py
@@ -412,7 +412,7 @@ def nxdata_ensure_definition(
     self,
     def_or_name: Property | str,
     *,
-    hint: str | None = None,
+    hint: Optional[str] = None,
 ) -> Property:
     current_cls = section_definitions[f"{_rename_nx_for_nomad('NXdata')}"].section_cls
     if isinstance(def_or_name, str):


### PR DESCRIPTION
In this code base there are some `| None` Which raise and error:
```
TypeError: unsupported operand type(s) for |: '_cython_3_0_11.cython_function_or_method' and 'NoneType'
```
This PR fix that