### PR TITLE
fix `atom_types` parsing

### DIFF
--- a/src/pynxtools/nomad/parser.py
+++ b/src/pynxtools/nomad/parser.py
@@ -478,6 +478,10 @@ class NexusParser(MatchingParser):
                     for symbol in atom_types.replace(" ", "").split(","):
                         if symbol in chemical_symbols[1:]:
                             element_set.add(symbol)
+                        else:
+                            self._logger.warn(
+                                f"Ignoring {symbol} as it is not for an element from the periodic table"
+                            )
                 # given that the element list will be overwritten
                 # in case a single chemical formula is found we do not add
                 # a chemical formula here as this anyway be correct only


### PR DESCRIPTION
This fixes the additional issue described in https://github.com/FAIRmat-NFDI/pynxtools/issues/583#issuecomment-3492130517. The problem was that 
```
(atom_types := sample.get("atom_types__field"))
```
does not actually return the value of `sample.atom_types__field`, but just the string `atom_types__field`. So we need to use the workaround presented here.

Local script for checking (using `nomad==1.4` and `pynxtools` from this branch):
```python
from nomad.datamodel import EntryArchive
from nomad.utils import get_logger
from pynxtools.nomad.parser import NexusParser

archive = EntryArchive()
NexusParser().parse(str("output.nxs"), archive, get_logger(__name__))

assert archive.data.ENTRY[0].specimen.atom_types__field == "C, Cr, Cu, O, Si"
assert archive.results.material.elements == ["C", "Cr", "Cu", "O", "Si"]
```

Here's the result section when running the GUI and appworker locally using the versions above:

<img width="1329" height="317" alt="image" src="https://github.com/user-attachments/assets/44853568-8f99-4d68-9ae1-6d533dd14241" />

@mkuehbach please test locally.