### PR TITLE
temporarily deactivate schema caching

### DIFF
--- a/src/pynxtools/nomad/schema.py
+++ b/src/pynxtools/nomad/schema.py
@@ -1158,7 +1158,8 @@ def init_nexus_metainfo():
     if nexus_metainfo_package is not None:
         return
     try:
-        load_nexus_schema()
+        # load_nexus_schema()
+        raise Exception("not loading cached schema for now")
 
     except Exception:
         nexus_metainfo_package = create_metainfo_package()


### PR DESCRIPTION
Since the JSON schema caching seems to break a couple things for now (especially with respect to normalizing). We can reactivate it if we can find a way around these issues.