### PR TITLE
remove hint at readers that no longer exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,6 @@ validate_nexus = "pynxtools.dataconverter.validate_file:validate_cli"
 
 [tool.setuptools.package-data]
 pynxtools = ["definitions/**/*.xml", "definitions/**/*.xsd"]
-"pynxtools.dataconverter.readers.hall" = ["enum_map.json"]
-"pynxtools.dataconverter.readers.rii_database.formula_parser" = ["dispersion_function_grammar.lark"]
 
 [tool.setuptools.packages.find]
 where = [


### PR DESCRIPTION
- hall reader was removed in #285, two years ago
- `rii_database` reader has been brought to https://github.com/domna/pynxtools-rii_database, will likely not be further pursued.