### PR TITLE
use `yaml.SafeLoader` everywhere

### DIFF
--- a/src/pynxtools/dataconverter/convert.py
+++ b/src/pynxtools/dataconverter/convert.py
@@ -233,7 +233,7 @@ def convert(
 
 def parse_params_file(params_file):
     """Parses the parameters from a given dictionary and returns them"""
-    params = yaml.load(params_file, Loader=yaml.Loader)["dataconverter"]
+    params = yaml.load(params_file, Loader=yaml.SafeLoader)["dataconverter"]
     for param in list(params.keys()):
         params[param.replace("-", "_")] = params.pop(param)
     return params


### PR DESCRIPTION
This is just to safeguard all our tools against code injection through YAML. All other `yaml.load` calls in pynxtools already use `yaml.SafeLoader`