### PR TITLE
initial plugin metadata extraction

### DIFF
--- a/.metadata/nomad_plugin_metadata.auto.yaml
+++ b/.metadata/nomad_plugin_metadata.auto.yaml
@@ -1,0 +1,327 @@
+id: pynxtools
+metadata_schema_version: 1.0.0
+name: pynxtools
+description: Extend NeXus for experiments and characterization in Materials Science
+  and Materials Engineering and serve as a NOMAD parser implementation for NeXus.
+license: LICENSE
+upstream_repository: https://github.com/FAIRmat-NFDI/pynxtools
+documentation: https://fairmat-nfdi.github.io/pynxtools/
+homepage: https://github.com/FAIRmat-NFDI/pynxtools
+issue_tracker: https://github.com/FAIRmat-NFDI/pynxtools/issues
+authors:
+- name: Sherjeel Shabih
+- name: Lukas Pielsticker
+- name: Florian Dobener
+- name: Andrea Albino
+- name: Theodore Chang
+- name: Carola Emminger
+- name: Lev Ginzburg
+- name: Ron Hildebrandt
+- name: "Markus K\xFChbach"
+- name: Rubel Mozumder
+- name: Tommaso Pincelli
+- name: Martin Aeschlimann
+- name: Marius Grundmann
+- name: Walid Hetaba
+- name: Carlos-Andres Palma
+- name: Laurenz Rettig
+- name: Markus Scheidgen
+- name: Sandor Brockhauser
+- name: "Jos\xE9 A. M\xE1rquez Prieto"
+- name: Claudia Draxl
+- name: Christoph T. Koch
+- name: Heiko B. Weber
+entry_points:
+- id: nomad.plugin:nexus_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: nexus_parser
+  python_object: pynxtools.nomad.parsers:nexus_parser
+  capability_type: parser
+- id: nomad.plugin:nexus_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: nexus_schema
+  python_object: pynxtools.nomad.schema_packages:nexus_schema
+  capability_type: schema
+- id: nomad.plugin:nexus_data_converter
+  entry_point_group: nomad.plugin
+  entry_point_name: nexus_data_converter
+  python_object: pynxtools.nomad.schema_packages:nexus_data_converter
+  capability_type: schema
+- id: nomad.plugin:nexus_app
+  entry_point_group: nomad.plugin
+  entry_point_name: nexus_app
+  python_object: pynxtools.nomad.apps:nexus_app
+  capability_type: app
+- id: nomad.plugin:simple_nexus_example
+  entry_point_group: nomad.plugin
+  entry_point_name: simple_nexus_example
+  python_object: pynxtools.nomad.example_uploads:simple_nexus_example
+  capability_type: example_upload
+capabilities:
+- id: nexus_parser
+  capability_type: parser
+  title: nexus_parser
+  parser_details:
+    parser_name: nexus_parser
+- id: nexus_schema
+  capability_type: schema
+  title: nexus_schema
+- id: nexus_data_converter
+  capability_type: schema
+  title: nexus_data_converter
+- id: nexus_app
+  capability_type: app
+  title: nexus_app
+- id: simple_nexus_example
+  capability_type: example_upload
+  title: simple_nexus_example
+schema_dependencies:
+- dependency_type: python_package
+  package_name: click
+  version_range: '>=7.1.2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: click_default_group
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: h5py
+  version_range: '>=3.6.0'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: xarray
+  version_range: '>=0.20.2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: PyYAML
+  version_range: '>=6.0'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: numpy
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: pandas
+  version_range: '>=1.3.2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: ase
+  version_range: '>=3.19.0'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: mergedeep
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: importlib-metadata
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: lxml
+  version_range: '>=4.9.1'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: toposort
+  version_range: '>=1.10.0'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: anytree
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: pint
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: cachetools
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: structlog
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: orjson
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: nomad-lab
+  version_range: '>= 1.4.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: markdown-exec
+  version_range: '[ansi]'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-material
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-material-extensions
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-macros-plugin
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-click
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: markdown-include
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mypy
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: ruff
+  version_range: '>=0.15.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-timeout
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-cov
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-xdist
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: types-pyyaml
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: types-pytz
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: types-requests
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pre-commit
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: debugpy
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools
+  version_range: '[apm,ellips,em,igor,mpes,raman,spm,xps,xrd]'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-apm
+  version_range: '>=0.2.3'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-ellips
+  version_range: '>=0.0.10'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-em
+  version_range: '>=0.3.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-igor
+  version_range: '>=0.1.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-mpes
+  version_range: '>=0.2.3'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-raman
+  version_range: '>=0.0.11'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-spm
+  version_range: '>=0.1.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-xps
+  version_range: '>=0.5.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-xrd
+  version_range: '>=0.0.5'
+  optional: true
+  purpose: optional
+metadata_provenance:
+- source: pyproject
+  extraction_method: deterministic
+  generated_at: '2026-03-19T15:18:48.314663+00:00'
+  generator_version: 0.1.0
+- source: plugin_entry_points
+  extraction_method: deterministic
+  generated_at: '2026-03-19T15:18:48.314700+00:00'
+  generator_version: 0.1.0
+- source: citation_cff
+  extraction_method: deterministic
+  generated_at: '2026-03-19T15:18:48.314714+00:00'
+  generator_version: 0.1.0
+stars: 21
+owner: FAIRmat-NFDI
+owner_type: Organization
+created: '2021-10-22T14:40:23Z'
+last_updated: '2026-03-17T16:37:30Z'
+archived: false

--- a/.metadata/nomad_plugin_metadata.auto.yaml
+++ b/.metadata/nomad_plugin_metadata.auto.yaml
@@ -309,15 +309,15 @@ schema_dependencies:
 metadata_provenance:
 - source: pyproject
   extraction_method: deterministic
-  generated_at: '2026-03-19T15:18:48.314663+00:00'
+  generated_at: '2026-03-19T15:20:32.681116+00:00'
   generator_version: 0.1.0
 - source: plugin_entry_points
   extraction_method: deterministic
-  generated_at: '2026-03-19T15:18:48.314700+00:00'
+  generated_at: '2026-03-19T15:20:32.681161+00:00'
   generator_version: 0.1.0
 - source: citation_cff
   extraction_method: deterministic
-  generated_at: '2026-03-19T15:18:48.314714+00:00'
+  generated_at: '2026-03-19T15:20:32.681176+00:00'
   generator_version: 0.1.0
 stars: 21
 owner: FAIRmat-NFDI

--- a/.metadata/nomad_plugin_metadata.manual.yaml
+++ b/.metadata/nomad_plugin_metadata.manual.yaml
@@ -1,0 +1,84 @@
+# Maintainer-owned metadata overrides and manual additions.
+# This file is never machine-overwritten after creation.
+# Use null/empty values as placeholders; only non-empty values override auto output.
+# list[str] domain/topic tags (e.g. "simulations", "spectroscopy")
+subject:
+  - cross-domain
+  - measurements
+  - nexus
+  - data-conversion
+  - data-standardization
+# enum {alpha, beta, stable, archived}
+maturity: stable
+# str, e.g. "main"
+repository_default_branch: main
+
+# Deployment flags.
+deployment:
+  # boolean
+  on_central: true
+  # boolean
+  on_example_oasis: true
+  # boolean
+  on_pypi: true
+  # str (PyPI package name)
+  pypi_package: pynxtools
+
+# Suggested usages for registry filtering/discovery.
+suggested_usages:
+  -
+    # str (stable ID slug), e.g. "parse-xrd-patterns"
+    id: convert-instrument-data-to-nexus
+    # str
+    title: Convert instrument data to NeXus
+    # str (what user wants to do), e.g. "Import and parse raw files"
+    user_intent: Transform heterogeneous experimental outputs into NeXus-compliant files
+    # enum {simulations, measurements, synthesis, cross-domain, workflow, infrastructure}
+    domain_category: cross-domain
+    # str, e.g. "XRD", "DFT"
+    technique: nexus-data-conversion
+    # str, e.g. "beginner", "expert"
+    audience: intermediate
+    # enum {alpha, beta, stable, archived}
+    maturity: stable
+    # list[str]
+    tags: [nexus, conversion, interoperability, readers]
+  -
+    # str (stable ID slug), e.g. "parse-xrd-patterns"
+    id: run-nexus-parser-in-nomad
+    # str
+    title: Parse NeXus files in NOMAD
+    # str (what user wants to do), e.g. "Import and parse raw files"
+    user_intent: Ingest and validate NeXus datasets through NOMAD parser/app integration
+    # enum {simulations, measurements, synthesis, cross-domain, workflow, infrastructure}
+    domain_category: infrastructure
+    # str, e.g. "XRD", "DFT"
+    technique: nexus-parser
+    # str, e.g. "beginner", "expert"
+    audience: advanced
+    # enum {alpha, beta, stable, archived}
+    maturity: stable
+    # list[str]
+    tags: [nomad, parser, app, nexus]
+
+# Optional file format metadata enrichments.
+file_format_support:
+  -
+    # str (stable ID), e.g. "csv"
+    id: nxs
+    # str display label, e.g. ".csv"
+    label: .nxs
+    # str capability reference (links to capabilities[].id), e.g. "vasp_parser"
+    capability_id: nexus_parser
+    # str producer/code family for ambiguous extensions, e.g. "vasp", "quantumespresso"
+    producer: nexus
+    # list[str] extensions including dot, e.g. [".csv", ".txt"]
+    extensions: [.nxs, .nx5, .h5, .hdf5]
+    # list[str], e.g. ["text/csv"]
+    mime_types: [application/x-hdf5]
+    # str, e.g. "CIF", "NeXus"
+    standard: NeXus
+    # str, instrument or context label
+    instrument_context: multi-technique
+    # str free text notes
+    notes: Canonical NeXus/HDF5 containers parsed or generated via pynxtools workflows.

--- a/.metadata/nomad_plugin_metadata.manual.yaml
+++ b/.metadata/nomad_plugin_metadata.manual.yaml
@@ -11,7 +11,7 @@ subject:
 # enum {alpha, beta, stable, archived}
 maturity: stable
 # str, e.g. "main"
-repository_default_branch: main
+repository_default_branch: master
 
 # Deployment flags.
 deployment:

--- a/.metadata/plugin-metadata.override-report.yaml
+++ b/.metadata/plugin-metadata.override-report.yaml
@@ -1,0 +1,4 @@
+summary:
+  overridden_field_count: 0
+  manual_precedence: true
+overridden_fields: []

--- a/nomad_plugin_metadata.yaml
+++ b/nomad_plugin_metadata.yaml
@@ -1,0 +1,380 @@
+id: pynxtools
+metadata_schema_version: 1.0.0
+name: pynxtools
+description: Extend NeXus for experiments and characterization in Materials Science
+  and Materials Engineering and serve as a NOMAD parser implementation for NeXus.
+license: LICENSE
+upstream_repository: https://github.com/FAIRmat-NFDI/pynxtools
+documentation: https://fairmat-nfdi.github.io/pynxtools/
+homepage: https://github.com/FAIRmat-NFDI/pynxtools
+issue_tracker: https://github.com/FAIRmat-NFDI/pynxtools/issues
+authors:
+- name: Sherjeel Shabih
+- name: Lukas Pielsticker
+- name: Florian Dobener
+- name: Andrea Albino
+- name: Theodore Chang
+- name: Carola Emminger
+- name: Lev Ginzburg
+- name: Ron Hildebrandt
+- name: "Markus K\xFChbach"
+- name: Rubel Mozumder
+- name: Tommaso Pincelli
+- name: Martin Aeschlimann
+- name: Marius Grundmann
+- name: Walid Hetaba
+- name: Carlos-Andres Palma
+- name: Laurenz Rettig
+- name: Markus Scheidgen
+- name: Sandor Brockhauser
+- name: "Jos\xE9 A. M\xE1rquez Prieto"
+- name: Claudia Draxl
+- name: Christoph T. Koch
+- name: Heiko B. Weber
+entry_points:
+- id: nomad.plugin:nexus_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: nexus_parser
+  python_object: pynxtools.nomad.parsers:nexus_parser
+  capability_type: parser
+- id: nomad.plugin:nexus_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: nexus_schema
+  python_object: pynxtools.nomad.schema_packages:nexus_schema
+  capability_type: schema
+- id: nomad.plugin:nexus_data_converter
+  entry_point_group: nomad.plugin
+  entry_point_name: nexus_data_converter
+  python_object: pynxtools.nomad.schema_packages:nexus_data_converter
+  capability_type: schema
+- id: nomad.plugin:nexus_app
+  entry_point_group: nomad.plugin
+  entry_point_name: nexus_app
+  python_object: pynxtools.nomad.apps:nexus_app
+  capability_type: app
+- id: nomad.plugin:simple_nexus_example
+  entry_point_group: nomad.plugin
+  entry_point_name: simple_nexus_example
+  python_object: pynxtools.nomad.example_uploads:simple_nexus_example
+  capability_type: example_upload
+capabilities:
+- id: nexus_parser
+  capability_type: parser
+  title: nexus_parser
+  parser_details:
+    parser_name: nexus_parser
+- id: nexus_schema
+  capability_type: schema
+  title: nexus_schema
+- id: nexus_data_converter
+  capability_type: schema
+  title: nexus_data_converter
+- id: nexus_app
+  capability_type: app
+  title: nexus_app
+- id: simple_nexus_example
+  capability_type: example_upload
+  title: simple_nexus_example
+schema_dependencies:
+- dependency_type: python_package
+  package_name: click
+  version_range: '>=7.1.2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: click_default_group
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: h5py
+  version_range: '>=3.6.0'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: xarray
+  version_range: '>=0.20.2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: PyYAML
+  version_range: '>=6.0'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: numpy
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: pandas
+  version_range: '>=1.3.2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: ase
+  version_range: '>=3.19.0'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: mergedeep
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: importlib-metadata
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: lxml
+  version_range: '>=4.9.1'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: toposort
+  version_range: '>=1.10.0'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: anytree
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: pint
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: cachetools
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: structlog
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: orjson
+  version_range: ''
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: nomad-lab
+  version_range: '>= 1.4.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: markdown-exec
+  version_range: '[ansi]'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-material
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-material-extensions
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-macros-plugin
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-click
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: markdown-include
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mypy
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: ruff
+  version_range: '>=0.15.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-timeout
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-cov
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-xdist
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: types-pyyaml
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: types-pytz
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: types-requests
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pre-commit
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: debugpy
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools
+  version_range: '[apm,ellips,em,igor,mpes,raman,spm,xps,xrd]'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-apm
+  version_range: '>=0.2.3'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-ellips
+  version_range: '>=0.0.10'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-em
+  version_range: '>=0.3.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-igor
+  version_range: '>=0.1.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-mpes
+  version_range: '>=0.2.3'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-raman
+  version_range: '>=0.0.11'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-spm
+  version_range: '>=0.1.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-xps
+  version_range: '>=0.5.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pynxtools-xrd
+  version_range: '>=0.0.5'
+  optional: true
+  purpose: optional
+metadata_provenance:
+- source: pyproject
+  extraction_method: deterministic
+  generated_at: '2026-03-19T15:18:48.314663+00:00'
+  generator_version: 0.1.0
+- source: plugin_entry_points
+  extraction_method: deterministic
+  generated_at: '2026-03-19T15:18:48.314700+00:00'
+  generator_version: 0.1.0
+- source: citation_cff
+  extraction_method: deterministic
+  generated_at: '2026-03-19T15:18:48.314714+00:00'
+  generator_version: 0.1.0
+stars: 21
+owner: FAIRmat-NFDI
+owner_type: Organization
+created: '2021-10-22T14:40:23Z'
+last_updated: '2026-03-17T16:37:30Z'
+archived: false
+subject:
+- cross-domain
+- measurements
+- nexus
+- data-conversion
+- data-standardization
+maturity: stable
+repository_default_branch: main
+deployment:
+  on_central: true
+  on_example_oasis: true
+  on_pypi: true
+  pypi_package: pynxtools
+suggested_usages:
+- id: convert-instrument-data-to-nexus
+  title: Convert instrument data to NeXus
+  user_intent: Transform heterogeneous experimental outputs into NeXus-compliant files
+  domain_category: cross-domain
+  technique: nexus-data-conversion
+  audience: intermediate
+  maturity: stable
+  tags:
+  - nexus
+  - conversion
+  - interoperability
+  - readers
+- id: run-nexus-parser-in-nomad
+  title: Parse NeXus files in NOMAD
+  user_intent: Ingest and validate NeXus datasets through NOMAD parser/app integration
+  domain_category: infrastructure
+  technique: nexus-parser
+  audience: advanced
+  maturity: stable
+  tags:
+  - nomad
+  - parser
+  - app
+  - nexus
+file_format_support:
+- id: nxs
+  label: .nxs
+  capability_id: nexus_parser
+  producer: nexus
+  extensions:
+  - .nxs
+  - .nx5
+  - .h5
+  - .hdf5
+  mime_types:
+  - application/x-hdf5
+  standard: NeXus
+  instrument_context: multi-technique
+  notes: Canonical NeXus/HDF5 containers parsed or generated via pynxtools workflows.

--- a/nomad_plugin_metadata.yaml
+++ b/nomad_plugin_metadata.yaml
@@ -309,15 +309,15 @@ schema_dependencies:
 metadata_provenance:
 - source: pyproject
   extraction_method: deterministic
-  generated_at: '2026-03-19T15:18:48.314663+00:00'
+  generated_at: '2026-03-19T15:20:32.681116+00:00'
   generator_version: 0.1.0
 - source: plugin_entry_points
   extraction_method: deterministic
-  generated_at: '2026-03-19T15:18:48.314700+00:00'
+  generated_at: '2026-03-19T15:20:32.681161+00:00'
   generator_version: 0.1.0
 - source: citation_cff
   extraction_method: deterministic
-  generated_at: '2026-03-19T15:18:48.314714+00:00'
+  generated_at: '2026-03-19T15:20:32.681176+00:00'
   generator_version: 0.1.0
 stars: 21
 owner: FAIRmat-NFDI
@@ -332,7 +332,7 @@ subject:
 - data-conversion
 - data-standardization
 maturity: stable
-repository_default_branch: main
+repository_default_branch: master
 deployment:
   on_central: true
   on_example_oasis: true


### PR DESCRIPTION
## Summary

This PR adds the first metadata extraction for `nomad-simulation-parsers` using the `nomad-plugin-metadata` pipeline.

## What to review

Please review **`nomad_plugin_metadata.yaml`**.  
This is the canonical, merged file intended for querying/registry usage.

## How files work

- `.metadata/nomad_plugin_metadata.auto.yaml`  
  Machine-generated metadata from package/plugin introspection.
- `.metadata/nomad_plugin_metadata.manual.yaml`  
  Maintainer-owned manual curation/overrides (not machine-overwritten).
- `nomad_plugin_metadata.yaml`  
  Final merged output (auto + manual; manual non-empty values take precedence).
- `.metadata/plugin-metadata.override-report.yaml`  
  Report of conflicts where manual overrides auto.

## Goal of this PR

Initial extraction pass for developer feedback before broader rollout:
- verify extracted parser/file-format metadata
- identify missing/incorrect fields
- align expected manual curation scope

## References

- `nomad-plugins-metadata`: https://github.com/FAIRmat-NFDI/nomad-plugins-metadata, https://fairmat-nfdi.github.io/nomad-plugins-metadata/reference/schema_reference.html#full-schema-shaped-yaml-template
- `datatractor`: https://github.com/datatractor
