### PR TITLE
Include the old convension to call nexsu_parser in the aliases list.

### DIFF
--- a/src/pynxtools/nomad/parsers/__init__.py
+++ b/src/pynxtools/nomad/parsers/__init__.py
@@ -36,4 +36,7 @@ nexus_parser = NexusParserEntryPoint(
     description="A parser for nexus files.",
     mainfile_name_re=r".*\.nxs",
     mainfile_mime_re="application/x-hdf*",
+    aliases=[
+        "pynxtools.nomad.entrypoints:nexus_parser",
+    ],
 )


### PR DESCRIPTION
closes #773 

In some previous version of `pynxtools`, we registered the nexus parser in a different way, `pynxtools.nomad.entrypoints:nexus_parser`. But later changing the entry point name to `pynxtools.nomad.parsers:nexus_parser` causes an error in nomad. This is fixed by adding the old convention in aliases in NexusParserEntryPoint.


I tested if the aliases are registered properly.

```ipython
In [1]: from nomad.parsing.parsers import match_parser, parser_dict, parsers

In [2]: for k, v in parser_dict.items():
   ...: 
   ...:     if 'pynxtools' in k:
   ...:         print(f"EntryPoint: {k}")
   ...:
EntryPoint: pynxtools.nomad.parsers:nexus_parser
EntryPoint: pynxtools.nomad.entrypoints:nexus_parser
```