### PR TITLE
refactor: introduce ValidationVisitor implementing NexusVisitor

### DIFF
--- a/.cspell/custom-dictionary.txt
+++ b/.cspell/custom-dictionary.txt
@@ -138,6 +138,7 @@ hashvalue
 hdfdict
 hdfgroup
 hdfobject
+hdfpath
 hfive
 hixu
 hyperslab
@@ -212,6 +213,7 @@ oned
 optionalities
 orcid
 otherfile
+otypes
 oxidising
 pathtovalidate
 plottable
@@ -269,4 +271,3 @@ ylabel
 zaxis
 zenodo
 zstd
-otypes

--- a/docs/how-tos/pynxtools/implement-a-visitor.md
+++ b/docs/how-tos/pynxtools/implement-a-visitor.md
@@ -34,6 +34,18 @@ class MyVisitor(NexusVisitor):
     def on_complete(self, root: h5py.File) -> None: pass
 ```
 
+Two additional optional hooks have default no-op implementations and may be overridden:
+
+| Hook | When called | Default |
+|------|-------------|---------|
+| `on_broken_link(hdf_path, link)` | A soft or external link cannot be resolved. The broken node is then skipped. | no-op |
+| `on_external_link(hdf_path, link)` | An external link is first encountered, *before* the handler opens the external file. | no-op |
+
+The `link` argument is an `h5py.SoftLink` or `h5py.ExternalLink` — inspect its type to distinguish the two cases.  Nodes from a successfully resolved external file are visited with the same `hdf_path` prefix as the link itself; for example, a link at `"entry/ext"` whose target is a group containing `"value"` results in `on_field("entry/ext/value", ...)`.
+
+!!! note "Hard links"
+    Hard links are followed transparently. A built-in cycle guard prevents infinite recursion when a hard-linked descendant aliases an ancestor.
+
 ## Worked example: collecting all field paths and values
 
 This visitor collects every field path and its scalar value into a flat dictionary.
@@ -132,6 +144,56 @@ logging.basicConfig(level=logging.INFO)
 visitor = SchemaAwareVisitor("NXarpes")
 NexusFileHandler("path/to/arpes_file.nxs").process(visitor)
 ```
+
+## Handling broken and external links
+
+Override `on_broken_link` and `on_external_link` to react to links that cannot be resolved or to external files that are traversed inline.
+
+```python
+from __future__ import annotations
+
+import h5py
+
+from pynxtools.nexus.handler import NexusFileHandler, NexusVisitor
+
+
+class LinkAwareVisitor(NexusVisitor):
+    """Report broken links and track which external files were opened."""
+
+    def __init__(self) -> None:
+        self.broken: list[tuple[str, str]] = []   # (hdf_path, link_target)
+        self.external_files: set[str] = set()
+
+    def on_group(self, hdf_path: str, hdf_node: h5py.Group) -> None:
+        pass
+
+    def on_field(self, hdf_path: str, hdf_node: h5py.Dataset) -> None:
+        pass
+
+    def on_attribute(self, hdf_path: str, attr_name: str, attr_value, parent) -> None:
+        pass
+
+    def on_complete(self, root: h5py.File) -> None:
+        pass
+
+    def on_broken_link(self, hdf_path: str, link) -> None:
+        target = getattr(link, "path", str(link))
+        self.broken.append((hdf_path, target))
+        print(f"BROKEN LINK at {hdf_path!r} → {target!r}")
+
+    def on_external_link(self, hdf_path: str, link: h5py.ExternalLink) -> None:
+        self.external_files.add(link.filename)
+        print(f"External file opened: {link.filename!r} for node {hdf_path!r}")
+
+
+# Usage
+visitor = LinkAwareVisitor()
+NexusFileHandler("path/to/file.nxs").process(visitor)
+print(f"Broken links: {visitor.broken}")
+print(f"External files referenced: {visitor.external_files}")
+```
+
+`on_broken_link` is called for both broken soft links (`h5py.SoftLink`) and broken external links (`h5py.ExternalLink`); inspect `type(link)` to distinguish them.  `on_external_link` fires only for external links, immediately before the external file is opened — it does not fire again for nodes inside the external subtree.
 
 ## Resolving the application definition from the file
 

--- a/docs/how-tos/pynxtools/implement-a-visitor.md
+++ b/docs/how-tos/pynxtools/implement-a-visitor.md
@@ -41,7 +41,7 @@ Two additional optional hooks have default no-op implementations and may be over
 | `on_broken_link(hdf_path, link)` | A soft or external link cannot be resolved. The broken node is then skipped. | no-op |
 | `on_external_link(hdf_path, link)` | An external link is first encountered, *before* the handler opens the external file. | no-op |
 
-The `link` argument is an `h5py.SoftLink` or `h5py.ExternalLink` — inspect its type to distinguish the two cases.  Nodes from a successfully resolved external file are visited with the same `hdf_path` prefix as the link itself; for example, a link at `"entry/ext"` whose target is a group containing `"value"` results in `on_field("entry/ext/value", ...)`.
+The `link` argument is an `h5py.SoftLink` or `h5py.ExternalLink`. Inspect its type to distinguish the two cases. Nodes from a successfully resolved external file are visited with the same `hdf_path` prefix as the link itself; for example, a link at `"entry/ext"` whose target is a group containing `"value"` results in `on_field("entry/ext/value", ...)`.
 
 !!! note "Hard links"
     Hard links are followed transparently. A built-in cycle guard prevents infinite recursion when a hard-linked descendant aliases an ancestor.
@@ -193,7 +193,7 @@ print(f"Broken links: {visitor.broken}")
 print(f"External files referenced: {visitor.external_files}")
 ```
 
-`on_broken_link` is called for both broken soft links (`h5py.SoftLink`) and broken external links (`h5py.ExternalLink`); inspect `type(link)` to distinguish them.  `on_external_link` fires only for external links, immediately before the external file is opened — it does not fire again for nodes inside the external subtree.
+`on_broken_link` is called for both broken soft links (`h5py.SoftLink`) and broken external links (`h5py.ExternalLink`); inspect `type(link)` to distinguish them.  `on_external_link` fires only for external links, immediately before the external file is opened. It does not fire again for nodes inside the external subtree.
 
 ## Resolving the application definition from the file
 

--- a/docs/how-tos/pynxtools/validate-nexus-files.md
+++ b/docs/how-tos/pynxtools/validate-nexus-files.md
@@ -131,6 +131,19 @@ pynx read src/pynxtools/data/201805_WSe2_arpes.nxs -d /entry/instrument/analyser
 
 If you run this call, you get a smaller subset of the full annotation log that helps you to understand which NeXus concept a given HDF5 object corresponds to.
 
+## Broken and external links
+
+`pynx validate` checks HDF5 links as part of normal traversal:
+
+- **Broken soft links** (the link target does not exist in the same file) are reported as a `BrokenLink` warning:
+  ```
+  WARNING - Broken link at /entry/missing_field to /nonexistent.
+  ```
+- **Broken external links** (the referenced file cannot be opened, or the path inside it does not exist) are also reported as `BrokenLink` warnings.
+- **Valid external links** are followed transparently — the external subtree is validated as if it were part of the main file.  No warning is emitted for a successfully resolved external link.
+
+The link type (`h5py.SoftLink` or `h5py.ExternalLink`) is available to custom visitors via the `link` argument of `on_broken_link`.  See [Implement a custom NexusVisitor](implement-a-visitor.md#handling-broken-and-external-links) for an example.
+
 ## Other approaches (not part of pynxtools)
 
 Aside from the tools we develop within FAIRmat, the [official NeXus website](https://manual.nexusformat.org/validation.html) lists additional programs for the validation of NeXus files:

--- a/docs/learn/pynxtools/architecture.md
+++ b/docs/learn/pynxtools/architecture.md
@@ -217,12 +217,14 @@ HDF5 file
     ▼
 NexusFileHandler.process(visitor)
     │
-    ├─ on_group  ─────────┐
-    ├─ on_field  ──────────┤ NexusVisitor
-    ├─ on_attribute ───────┤  (Annotator / NomadVisitor / custom)
-    └─ on_complete ────────┘
+    ├─ on_group  ───────────┐
+    ├─ on_field  ───────────┤ NexusVisitor
+    ├─ on_attribute ────────┤  (Annotator / NomadVisitor / custom)
+    ├─ on_broken_link ──────┤  (optional — default no-op)
+    ├─ on_external_link ────┤  (optional — default no-op)
+    └─ on_complete ─────────┘
               │
-              │  node_for(hdf_path, hdf_node)
+              │  node_for(hdf_path, hdf_node) ──► NexusNode lookup (per node)
               ▼
     NexusSchemaResolver
     ├─ appdef_for(hdf_node) ──► NXentry/definition (str | None)

--- a/docs/learn/pynxtools/architecture.md
+++ b/docs/learn/pynxtools/architecture.md
@@ -93,7 +93,9 @@ The root group itself is dispatched as a group with `hdf_path = ""`.
 
 ## The processing layer: `NexusVisitor`
 
-`NexusVisitor` (in `pynxtools.nexus.handler`) is the extension point. It is an abstract base class (`ABC`) that declares four hooks. All four must be implemented by concrete subclasses; hooks that are not meaningful for a particular visitor should be implemented as `pass`.
+`NexusVisitor` (in `pynxtools.nexus.handler`) is the extension point. It is an abstract base class (`ABC`) that declares four mandatory hooks and two optional hooks.
+
+The four mandatory hooks must be implemented by every concrete subclass; implement hooks that are not meaningful as `pass`:
 
 ```python
 from abc import ABC, abstractmethod
@@ -117,11 +119,19 @@ class NexusVisitor(ABC):
     def on_complete(self, root: h5py.File) -> None: ...
 ```
 
+Two optional hooks have default no-op implementations and may be overridden:
+
+| Hook | When called |
+|------|-------------|
+| `on_broken_link(hdf_path, link)` | A soft or external link cannot be resolved; the broken node is skipped. |
+| `on_external_link(hdf_path, link)` | An external link is encountered, *before* the handler opens the external file. |
+
 ### Built-in visitor implementations
 
 | Visitor | Module | CLI tool | Purpose |
 |---|---|---|---|
 | `Annotator` | `pynxtools.annotator.annotator` | `pynx read` | Logs NXDL documentation for every node in a NeXus file |
+| `ValidationVisitor` | `pynxtools.dataconverter.validation` | `pynx validate` | Checks every node against its NXDL constraints |
 | `NomadVisitor` | `pynxtools.nomad.parsers.parser` | `nomad parse` | Populates the NOMAD archive from a NeXus file |
 
 All built-in visitors are interchangeable in `NexusFileHandler`. Switching the visitor changes what happens to each node; the traversal is identical.
@@ -185,6 +195,19 @@ Three operating modes are supported:
 - **Default**: annotate every node and print the default-plottable summary.
 - **`-d` (documentation)**: annotate only the single node at a given HDF5 path.
 - **`-c` (concept)**: find all HDF5 nodes that implement a given NXDL concept path.
+
+### `pynx validate` — the validator
+
+`validate` creates a `ValidationVisitor` and passes it to `NexusFileHandler`. The validator checks:
+
+- required, recommended, and optional fields are present where expected,
+- field values conform to their `NexusType` and unit category,
+- enumeration values are in-range (warnings for closed enumerations, info for open),
+- `NXdata` signal and axis dimensionality rules are satisfied,
+- HDF5 links resolve correctly and carry a `@target` attribute; broken soft or external links are reported as `BrokenLink` problems,
+- reserved suffixes and prefixes are used in valid contexts.
+
+Validation state accumulates across callbacks and the summary report is emitted in `on_complete`.
 
 ## Data flow summary
 

--- a/src/pynxtools/dataconverter/helpers.py
+++ b/src/pynxtools/dataconverter/helpers.py
@@ -1031,9 +1031,12 @@ def is_valid_enum(
             if nxdl_enum_open:
                 custom_path = get_custom_attr_path(path)
 
-                if isinstance(mapping, h5py.Group):
-                    parent_path, attr_name = custom_path.rsplit("@", 1)
-                    custom_attr = mapping.get(parent_path).attrs.get(attr_name)
+                if isinstance(mapping, (h5py.Group, h5py.Dataset)):
+                    # HDF5 object passed directly — the custom attr lives on its own attrs.
+                    # custom_path is like "/entry/field/@attr_custom" or "/entry/field/@custom";
+                    # only the last component (after the final "@") matters.
+                    attr_name = custom_path.rsplit("@", 1)[-1]
+                    custom_attr = decode_if_bytes(mapping.attrs.get(attr_name))
                     custom_added_auto = False
                 else:
                     custom_attr = mapping.get(custom_path)
@@ -1057,8 +1060,9 @@ def is_valid_enum(
                 elif custom_attr is None:
                     try:
                         mapping[custom_path] = True
-                    except ValueError:
-                        # we are in the HDF5 validation, cannot set custom attribute.
+                    except (ValueError, TypeError):
+                        # HDF5 objects are read-only during validation.
+                        # Custom attribute cannot be set.
                         pass
                     collector.collect_and_log(
                         path,

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -32,8 +32,6 @@ import logging
 import h5py
 import lxml.etree as ET
 import numpy as np
-from cachetools import LRUCache, cached
-from cachetools.keys import hashkey
 
 from pynxtools.dataconverter.helpers import (
     Collector,
@@ -58,8 +56,10 @@ from pynxtools.nexus.nexus_tree import (
     NexusField,
     NexusGroup,
     NexusNode,
+    _select_best_namefit,
     generate_tree_from,
 )
+from pynxtools.nexus.schema_resolver import NexusSchemaResolver, resolve_path
 from pynxtools.units import NXUnitSet, ureg
 
 logger = logging.getLogger("pynxtools")
@@ -218,16 +218,12 @@ class ValidationVisitor(NexusVisitor):
         """
         collector.clear()
 
-        appdef_node = generate_tree_from(appdef)
+        self._resolver = NexusSchemaResolver()
+        appdef_node = self._resolver.tree_for(appdef)
         self._tree: NexusNode = appdef_node.search_add_child_for("ENTRY")
         self._appdef_node: NexusNode = appdef_node
         self._entry_name: str = entry_name
         self._ignore_undocumented: bool = ignore_undocumented
-
-        # Cache keyed by path only (same semantics as the original LRUCache with
-        # key=hashkey(path) — node_type/nx_class/hint are not part of the cache key)
-        self._node_cache: dict[str, NexusNode | None] = {}
-        self._MISSING = object()  # sentinel for "not yet cached"
 
         self._required_groups: set[str] = set()
         self._required_entities: set[str] = set()
@@ -347,80 +343,6 @@ class ValidationVisitor(NexusVisitor):
     # Schema resolution
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _best_namefit_of(
-        name: str,
-        nodes: Sequence[NexusNode],
-        hint: Literal["axis", "signal"] | None = None,
-    ) -> NexusNode | None:
-        """
-        Get the best namefit of `name` in `nodes`.
-
-        Args:
-            name (str): The name to fit against the nodes.
-            nodes (Sequence[NexusNode]): The nodes to fit `name` against.
-            node_type (str): The type (group, field, attribute) that is expected
-
-        Returns:
-            Optional[NexusNode]: The best fitting node. None if no fit was found.
-        """
-        if not nodes:
-            return None
-
-        best_match: NexusNode | None = None
-        best_score = -1
-
-        # use score as key for the outer dict and inner dict as value with
-        # constraint as key and idx on nodes as value on that inner dict
-        score_board: dict[int, dict[str, list[int]]] = {}
-
-        hint_map: dict[str, str] = {"DATA": "signal", "AXISNAME": "axis"}
-
-        for idx, node in enumerate(nodes):
-            if not node.variadic:
-                if name == node.name:
-                    return node
-            else:
-                name_any = node.name_type == "any"
-                name_partial = node.name_type == "partial"
-                score = get_nx_namefit(name, node.name, name_any, name_partial)
-                if score > best_score:
-                    if hint and hint_map.get(node.name) != hint:
-                        continue
-                    best_match = node
-                    best_score = score
-
-                if score in score_board:
-                    pass
-                else:
-                    score_board[score] = {
-                        "required": [],
-                        "recommended": [],
-                        "optional": [],
-                    }
-                for constraint in ["optional", "required", "recommended"]:
-                    # lookup into nodes in decreasing order of typical occurrence to break earlier
-                    if node.optionality == constraint:
-                        score_board[score][constraint].append(idx)
-                        break
-
-        # analyze and warn if more than one concept fits best, return always though the first found
-        if len(score_board) > 0:
-            alternative_best_score = max(score_board)
-            if alternative_best_score > -1:
-                for constraint in ["required", "recommended", "optional"]:
-                    # select preferentially for the harder constraint that should be met given that
-                    # we wish to validate compliance with a NeXus definition (appdef or class)
-                    if len(score_board[alternative_best_score][constraint]) > 1:
-                        logger.debug(
-                            f"Multiple best fitting with score {alternative_best_score} found "
-                            f"{[nodes[idx] for idx in score_board[alternative_best_score][constraint]]} "
-                            f"constrained by {constraint}; indicates possible issues with nameTyping of "
-                            f"specific NeXus classes/concepts"
-                        )
-
-        return best_match
-
     def _find_node_for(
         self,
         path: str,
@@ -428,64 +350,48 @@ class ValidationVisitor(NexusVisitor):
         nx_class: str | None = None,
         hint: Literal["axis", "signal"] | None = None,
     ) -> NexusNode | None:
-        """
-        Find the NexusNode for *path*, cached by path only.
+        """Find the NexusNode for *path*, delegating to the schema resolver.
+
+        Uses :meth:`~pynxtools.nexus.schema_resolver.NexusSchemaResolver.node_for_path`
+        for resolution and caching, then adds type-conflict detection on top: if the
+        path matches a concept of a different type (e.g. a field path that refers to a
+        group concept), a validation problem is logged and ``TypeError`` is raised.
 
         Raises:
             TypeError: If the path matches a concept of a conflicting type.
         """
-        cached = self._node_cache.get(path, self._MISSING)
-        if cached is not self._MISSING:
-            return cached  # type: ignore[return-value]
-
-        if path == "":
+        if not path:
             return self._tree
 
-        *prev_parts, last_elem = path.rsplit("/", 1)
-        parent = (
-            self._find_node_for(prev_parts[0], hint=hint) if prev_parts else self._tree
+        node = self._resolver.node_for_path(
+            self._tree, path, node_type=node_type, nx_class=nx_class, hint=hint
         )
-        parent_copy = copy.copy(parent)
-
-        if parent is None:
-            self._node_cache[path] = None
-            return None
-
-        children_to_check = [
-            parent.search_add_child_for(child)
-            for child in parent.get_all_direct_children_names(
-                nx_class=nx_class, node_type=node_type
-            )
-        ]
-        node = self._best_namefit_of(last_elem, children_to_check, hint)
 
         if node is None:
-            other_node_types = [
-                nt for nt in self._POSSIBLE_NODE_TYPES if nt != node_type
-            ]
-            for other_node_type in other_node_types:
-                other_children = [
-                    parent_copy.search_add_child_for(child)
-                    for child in parent_copy.get_all_direct_children_names(
-                        node_type=other_node_type, nx_class=nx_class
-                    )
-                ]
-                other_node = self._best_namefit_of(last_elem, other_children)
-                if other_node is not None and not other_node.variadic:
-                    collector.collect_and_log(
-                        path,
-                        ValidationProblem.InvalidNexusTypeForNamedConcept,
-                        other_node,
-                        node_type,
-                    )
-                    raise TypeError(
-                        f"The type ('{node_type}') of {path} conflicts with another existing "
-                        f"concept {other_node.get_path()} (which is of type '{other_node.nx_type}')."
-                    )
-            self._node_cache[path] = None
-            return None
+            *parent_parts, last_seg = path.rsplit("/", 1)
+            parent_path = parent_parts[0] if parent_parts else ""
+            parent_node = (
+                self._resolver.node_for_path(self._tree, parent_path)
+                if parent_path
+                else self._tree
+            )
+            if parent_node is not None:
+                for other_type in self._POSSIBLE_NODE_TYPES:
+                    if other_type == node_type:
+                        continue
+                    other = parent_node.best_child_for(last_seg, node_type=other_type)
+                    if other is not None and not other.variadic:
+                        collector.collect_and_log(
+                            path,
+                            ValidationProblem.InvalidNexusTypeForNamedConcept,
+                            other,
+                            node_type,
+                        )
+                        raise TypeError(
+                            f"The type ('{node_type}') of {path} conflicts with another existing "
+                            f"concept {other.get_path()} (which is of type '{other.nx_type}')."
+                        )
 
-        self._node_cache[path] = node
         return node
 
     # ------------------------------------------------------------------
@@ -516,38 +422,38 @@ class ValidationVisitor(NexusVisitor):
         path: str,
         variadic_name: str,
         node_type: Literal["group", "field", "attribute"] | None = None,
-    ):
+    ) -> bool:
+        """Check if a required NXDL concept path *variadic_name* is satisfied by *path*.
+
+        *variadic_name* is a schema-level concept path (e.g. ``"instrument/DETECTOR"``);
+        *path* is the actual HDF5 instance path visited (e.g. ``"instrument/detector_1"``).
+        Returns ``True`` when the concept at *variadic_name* is variadic and the last
+        segment of *path* namefits it.
+
+        Uses :func:`~pynxtools.nexus.schema_resolver.resolve_path` directly on the schema
+        tree — deliberately bypassing the resolver cache to avoid mixing NXDL concept
+        paths with HDF5 instance paths in the shared cache.
         """
-        Check if a variadic node exists that matches a given path and node type.
 
-        Args:
-            path (str): Path to check.
-            variadic_name (str): Variadic name to compare.
-            node_type (Optional[str]): Type of node to restrict search.
-
-        Returns:
-            bool: True if a matching variadic node exists.
-        """
-
-        def _parent_of(path: str) -> str:
-            if "/" not in path.strip("/"):
-                return ""
-            return path.rstrip("/").rsplit("/", 1)[0]
+        def _parent_of(p: str) -> str:
+            return p.rstrip("/").rsplit("/", 1)[0] if "/" in p.strip("/") else ""
 
         if _parent_of(variadic_name) != _parent_of(path):
             return False
 
-        node = self._find_node_for(variadic_name, node_type=node_type)
-        if node is not None and node.variadic:
-            score = get_nx_namefit(
+        concept_node = resolve_path(self._tree, variadic_name, node_type=node_type)
+        if concept_node is None or not concept_node.variadic:
+            return False
+
+        return (
+            get_nx_namefit(
                 path.rsplit("/", 1)[-1],
-                node.name,
-                node.name_type == "any",
-                node.name_type == "partial",
+                concept_node.name,
+                concept_node.name_type == "any",
+                concept_node.name_type == "partial",
             )
-            if score > -1:
-                return True
-        return False
+            >= 0
+        )
 
     def _remove_from_req_groups(self, path: str) -> None:
         """
@@ -1634,8 +1540,6 @@ def validate_dict_against(
 
         concept_name, instance_name = split_class_and_name_of(name)
 
-        best_match = None
-
         for node in nodes:
             if not node.variadic:
                 if instance_name == node.name:
@@ -1678,21 +1582,14 @@ def validate_dict_against(
                                 )
                             return None
                     return node
-            else:
-                if concept_name and concept_name == node.name:
-                    if instance_name == node.name:
-                        return node
-
-                    name_any = node.name_type == "any"
-                    name_partial = node.name_type == "partial"
-
-                    score = get_nx_namefit(
-                        instance_name, node.name, name_any, name_partial
-                    )
-                    if score > -1:
-                        best_match = node
-
-        return best_match
+        # Variadic branch: filter to candidates whose concept name matches, then
+        # use the shared scoreboard selection (same logic as NexusNode.best_child_for).
+        variadic_candidates = [
+            n
+            for n in nodes
+            if n.variadic and (not concept_name or n.name == concept_name)
+        ]
+        return _select_best_namefit(instance_name, variadic_candidates)
 
     def add_best_matches_for(
         key: str, node: NexusNode, check_types: bool = False

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -62,7 +62,7 @@ from pynxtools.nexus.nexus_tree import (
 from pynxtools.nexus.schema_resolver import NexusSchemaResolver, resolve_path
 from pynxtools.units import NXUnitSet, ureg
 
-logger = logging.getLogger("pynxtools")
+logger = logging.getLogger(__file__)
 
 if DEBUG_VALIDATION:
     debugpy.debug_this_thread()

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -816,13 +816,15 @@ class ValidationVisitor(NexusVisitor):
             )
 
         for req_concept in sorted(self._required_entities):
-            if any(req_concept.startswith(grp) for grp in self._required_groups):
+            if any(req_concept.startswith(grp + "/") for grp in self._required_groups):
                 continue
             if "@" in req_concept:
-                if any(
-                    req_concept.rsplit("@", 1)[0].startswith(ent)
-                    for ent in self._required_entities
-                ):
+                # Suppress attribute if its parent field is itself missing —
+                # fixing the field implicitly fixes the attribute.
+                # Use the exact parent path (before "/@") to avoid false matches
+                # where one field name is a prefix of another
+                # (e.g. "sensor/@attr" vs "my_sensor/@attr").
+                if req_concept.rsplit("/@", 1)[0] in self._required_entities:
                     continue
                 collector.collect_and_log(
                     f"{self._entry_name}/{req_concept}",

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -53,6 +53,7 @@ from pynxtools.dataconverter.helpers import (
     split_class_and_name_of,
 )
 from pynxtools.definitions.dev_tools.utils.nxdl_utils import get_nx_namefit
+from pynxtools.nexus.handler import NexusFileHandler, NexusVisitor
 from pynxtools.nexus.nexus_tree import (
     NexusField,
     NexusGroup,
@@ -170,29 +171,161 @@ def is_valid_unit_for_node(
     )
 
 
-def validate_hdf_group_against(
-    appdef: str,
-    data: h5py.Group,
-    filename: str,
-    ignore_undocumented: bool = False,
-) -> bool:
+class ValidationVisitor(NexusVisitor):
     """
     Validate an HDF5 group against the Nexus tree for the application definition `appdef`.
 
-    Args:
-        appdef (str): The application definition to validate against.
-        data (h5py.Group): The h5py group to validate.
-        filename (str): The filename of the h5py group.
-        ignore_undocumented (bool, optional):
-            Ignore all undocumented items in the verification
-            and just check if the required concepts are properly set.
-            Defaults to False.
+    Implements :class:`~pynxtools.nexus.handler.NexusVisitor` so it can be
+    driven by :class:`~pynxtools.nexus.handler.NexusFileHandler`.
 
-    Returns:
-        bool: True if the group is valid according to `appdef`, False otherwise.
+    Encapsulates all schema resolution and required-concept tracking that was
+    previously implemented as closures inside ``validate_hdf_group_against``.
+
+    Usage::
+
+        visitor = ValidationVisitor(appdef, entry_name, ignore_undocumented)
+        NexusFileHandler(filename).process(visitor)
+        is_valid = not collector.has_validation_problems()
     """
 
-    def best_namefit_of(
+    _POSSIBLE_NODE_TYPES: tuple[str, ...] = ("group", "field", "attribute")
+    _SKIP_ATTRS: frozenset[str] = frozenset({"NX_class", "units", "target", "custom"})
+
+    def __init__(
+        self,
+        appdef: str,
+        entry_name: str,
+        ignore_undocumented: bool = False,
+    ) -> None:
+        """
+        Args:
+            appdef: Application definition name (e.g. ``"NXarpes"``).
+            entry_name: Absolute HDF5 path of the NXentry to validate
+                (e.g. ``"/entry"``).
+            ignore_undocumented: When ``True`` undocumented fields and groups
+                are silently skipped; only required concepts are checked.
+        """
+        collector.clear()
+
+        appdef_node = generate_tree_from(appdef)
+        self._tree: NexusNode = appdef_node.search_add_child_for("ENTRY")
+        self._appdef_node: NexusNode = appdef_node
+        self._entry_name: str = entry_name
+        self._ignore_undocumented: bool = ignore_undocumented
+
+        # Cache keyed by path only (same semantics as the original LRUCache with
+        # key=hashkey(path) — node_type/nx_class/hint are not part of the cache key)
+        self._node_cache: dict[str, NexusNode | None] = {}
+        self._MISSING = object()  # sentinel for "not yet cached"
+
+        self._required_groups: set[str] = set()
+        self._required_entities: set[str] = set()
+        self._update_required_concepts("", self._tree)
+
+        # Set in on_group when the NXentry group is first seen; used by
+        # is_valid_enum for open-enumeration custom-attribute lookups.
+        self._data: h5py.Group | None = None
+
+    # ------------------------------------------------------------------
+    # NexusVisitor interface
+    # ------------------------------------------------------------------
+
+    def on_group(self, hdf_path: str, hdf_node: h5py.Group) -> None:
+        """Validate an HDF5 group and its attributes."""
+        rel = self._entry_relative(hdf_path)
+        if rel is None:
+            return
+        if rel == "":
+            # This IS the NXentry group — store for is_valid_enum lookups.
+            self._data = hdf_node
+            return
+        self._check_soft_link(rel, hdf_node)
+        self._handle_group(rel, hdf_node)
+        self._handle_attributes(rel, hdf_node.attrs, hdf_node)
+
+    def on_field(self, hdf_path: str, hdf_node: h5py.Dataset) -> None:
+        """Validate an HDF5 dataset (field) and its attributes."""
+        rel = self._entry_relative(hdf_path)
+        if rel is None or rel == "":
+            return
+        self._check_soft_link(rel, hdf_node)
+        self._handle_field(rel, hdf_node)
+        check_reserved_suffix(f"{self._entry_name}/{rel}", hdf_node.parent)
+        self._handle_attributes(rel, hdf_node.attrs, hdf_node)
+
+    def on_attribute(
+        self,
+        hdf_path: str,
+        attr_name: str,
+        attr_value: Any,
+        parent: h5py.Group | h5py.Dataset,
+    ) -> None:
+        # Attributes are handled inside on_group / on_field via
+        # _handle_attributes so that the full attrs dict is available.
+        pass
+
+    def on_complete(self, root: h5py.File) -> None:
+        """Emit validation errors for all required concepts not encountered."""
+        self._report_missing()
+
+    def _entry_relative(self, hdf_path: str) -> str | None:
+        """Return *hdf_path* relative to this entry, or ``None`` if outside.
+
+        Returns ``""`` when *hdf_path* IS the entry itself.
+        """
+        entry_stripped = self._entry_name.lstrip("/")
+        if hdf_path == entry_stripped:
+            return ""
+        if hdf_path.startswith(entry_stripped + "/"):
+            return hdf_path[len(entry_stripped) + 1 :]
+        return None
+
+    def _check_soft_link(
+        self, rel_path: str, hdf_node: h5py.Group | h5py.Dataset
+    ) -> None:
+        """Validate the ``@target`` attribute of a direct soft link within the entry.
+
+        If the immediate parent path of *rel_path* contains a soft link to
+        *rel_path*'s last component, checks that the node has a ``@target``
+        attribute and that it matches the link's target path.
+        """
+        if self._data is None:
+            return
+        parts = rel_path.split("/")
+        child_name = parts[-1]
+        parent_rel = "/".join(parts[:-1]) if len(parts) > 1 else ""
+        parent = self._data if parent_rel == "" else self._data.get(parent_rel)
+        if parent is None or not isinstance(parent, h5py.Group):
+            return
+        link = parent.get(child_name, getlink=True)
+        if not isinstance(link, h5py.SoftLink):
+            return
+        target_path = link.path
+        full_path = f"{self._entry_name}/{rel_path}"
+        if "target" not in hdf_node.attrs:
+            collector.collect_and_log(
+                full_path,
+                ValidationProblem.MissingTargetAttribute,
+                None,
+            )
+        else:
+            attr_target = hdf_node.attrs["target"]
+            if isinstance(attr_target, bytes):
+                attr_target = attr_target.decode()
+            if attr_target != target_path:
+                collector.collect_and_log(
+                    full_path,
+                    ValidationProblem.TargetAttributeMismatch,
+                    attr_target,
+                    target_path,
+                )
+
+    # ------------------------------------------------------------------
+    # Schema resolution
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _best_namefit_of(
         name: str,
         nodes: Sequence[NexusNode],
         hint: Literal["axis", "signal"] | None = None,
@@ -446,12 +579,10 @@ def validate_hdf_group_against(
         if path in required_entities:
             required_entities.remove(path)
         else:
-            # Check if a variadic required node exists
-            for ent in list(required_entities):
-                node_type: Literal["group", "field", "attribute"] = (
+            for ent in list(self._required_entities):
+                node_type: Literal["attribute", "field"] = (
                     "attribute" if "@" in ent else "field"
                 )
-
                 clean_path = (
                     path.rstrip("/@units")
                     if path.endswith("@units") and ent.endswith("@units")
@@ -468,47 +599,68 @@ def validate_hdf_group_against(
                 ):
                     required_entities.remove(ent)
 
-    def _check_for_nxcollection_parent(node: NexusNode):
+    # ------------------------------------------------------------------
+    # HDF5 handlers
+    # ------------------------------------------------------------------
+
+    def _is_canonical_path(self, rel_path: str) -> bool:
+        """Return ``True`` if *rel_path* does not pass through any soft link
+        ancestor.
+
+        When a node is reached via a soft link ancestor, the HDF5 ``.name``
+        property and the logical path are the same (h5py uses the access path).
+        This helper detects link-based paths so that undocumented-node warnings
+        are suppressed for nodes that are only visible through a link — matching
+        the behavior of the old ``_visititems`` implementation.
         """
-        Check if the given node has a parent group of type NXcollection.
+        if self._data is None:
+            return True
+        parts = rel_path.split("/")
+        for depth in range(1, len(parts) + 1):
+            ancestor_path = "/".join(parts[:depth])
+            parent_path = "/".join(parts[: depth - 1]) if depth > 1 else None
+            if parent_path is not None:
+                parent = self._data.get(parent_path)
+            else:
+                parent = self._data
+            if parent is not None and isinstance(parent, h5py.Group):
+                child_name = parts[depth - 1]
+                link = parent.get(child_name, getlink=True)
+                if isinstance(link, h5py.SoftLink):
+                    return False
+        return True
+
+    def _has_breakpoint_at(self, rel_path: str, include_self: bool = False) -> bool:
+        """Return ``True`` if any ancestor of *rel_path* within the NXentry is
+        an NXcollection or lacks an NX_class attribute.
+
+        *rel_path* is a slash-separated path relative to the NXentry, e.g.
+        ``"identified_calibration/identifier_1"``.  Each *ancestor* component
+        (not the leaf itself, unless *include_self* is ``True``) is looked up in
+        ``self._data`` (the NXentry group) so that soft-link paths are walked by
+        their link path, not by the target's actual parent chain.
+
+        Dataset ancestors are skipped (they have no NX_class themselves).
 
         Args:
-            node (NexusNode): The node to check.
-
-        Returns:
-            bool: True if a parent NXcollection group exists.
+            rel_path: Path relative to the NXentry to check.
+            include_self: When ``True``, also check the node at *rel_path*
+                itself (useful for attribute-owner groups).
         """
-        parent = node.parent
-        while parent:
-            if parent.nx_type == "group" and parent.nx_class == "NXcollection":
-                # Found a parent collection group
+        if self._data is None:
+            return False
+        parts = rel_path.split("/")
+        upper = len(parts) + 1 if include_self else len(parts)
+        # Walk from outermost ancestor up to (but not including) the node itself,
+        # or including it when include_self=True.
+        for depth in range(1, upper):
+            ancestor_path = "/".join(parts[:depth])
+            ancestor = self._data.get(ancestor_path)
+            if ancestor is None:
                 return True
-            parent = parent.parent
-
-        return False
-
-    def has_breakpoint(key_path: str) -> bool:
-        """
-        Walk up the path hierarchy and check if a parent is an NXcollection
-        or has no NX_class, indicating we should stop.
-
-        For attributes of datasets, skip the dataset itself and continue with
-        its parent group.
-
-        Args:
-            path (str): HDF5 path to start from (no @attr suffix).
-
-        Returns:
-            bool: True if a breakpoint was found, False otherwise.
-        """
-        while "/" in key_path:
-            key_path = key_path.rsplit("/", 1)[0]
-            parent_data = data.get(key_path)
-            if isinstance(parent_data, h5py.Dataset):
+            if isinstance(ancestor, h5py.Dataset):
                 continue
-            nx_class = (
-                parent_data.attrs.get("NX_class") if parent_data is not None else None
-            )
+            nx_class = ancestor.attrs.get("NX_class")
             if nx_class == "NXcollection" or nx_class is None:
                 return True
         return False
@@ -526,8 +678,7 @@ def validate_hdf_group_against(
         check_reserved_prefix(full_path, appdef_node.name, "group")
 
         if not group.attrs.get("NX_class"):
-            # We ignore additional groups that don't have an NX_class
-            if not ignore_undocumented and full_path == group.name:
+            if not self._ignore_undocumented and self._is_canonical_path(path):
                 collector.collect_and_log(
                     full_path, ValidationProblem.MissingNXclass, None
                 )
@@ -540,7 +691,7 @@ def validate_hdf_group_against(
         except TypeError:
             return
         if node is None:
-            if not ignore_undocumented and full_path == group.name:
+            if not self._ignore_undocumented and self._is_canonical_path(path):
                 collector.collect_and_log(
                     full_path, ValidationProblem.MissingDocumentation, None
                 )
@@ -639,10 +790,10 @@ def validate_hdf_group_against(
         path: str,
         dataset: h5py.Dataset,
         hint: Literal["axis", "signal"] | None = None,
-    ):
+    ) -> None:
         """
-        Validate a NeXus field (dataset) within the HDF5 structure.
-
+        Validate an HDF5 dataset (NeXus field) against the schema tree.
+        
         Args:
             path (str): Path to the dataset.
             data (h5py.Dataset): Dataset object.
@@ -650,11 +801,9 @@ def validate_hdf_group_against(
                 If the field is in an NXdata group, this is used to figure out
                 if it is an AXISNAME or a DATA.
         """
-        full_path = f"{entry_name}/{path}"
-        key_path = path.replace("@", "")
+        full_path = f"{self._entry_name}/{path}"
 
-        if has_breakpoint(key_path):
-            # We are inside an NXcollection or a group without NX_class.
+        if self._has_breakpoint_at(path):
             return
 
         check_reserved_prefix(full_path, appdef_node.name, "field")
@@ -665,8 +814,7 @@ def validate_hdf_group_against(
             return
 
         if node is None:
-            # Only report undocumented if the group is not linked
-            if not ignore_undocumented and full_path == dataset.name:
+            if not self._ignore_undocumented and self._is_canonical_path(path):
                 collector.collect_and_log(
                     full_path, ValidationProblem.MissingDocumentation, None
                 )
@@ -724,8 +872,7 @@ def validate_hdf_group_against(
             is_valid_unit_for_node(node, units, units_path, hints)
 
         elif units is not None:
-            # Only report undocumented if the field is not linked
-            if not ignore_undocumented and full_path == dataset.name:
+            if not self._ignore_undocumented and self._is_canonical_path(path):
                 collector.collect_and_log(
                     units_path,
                     ValidationProblem.UnitWithoutDocumentation,
@@ -757,11 +904,10 @@ def validate_hdf_group_against(
                 # Ignore special attrs
                 continue
 
-            key_path = f"{path}/{attr_name}"
+            full_path = f"{self._entry_name}/{path}/@{attr_name}"
 
-            if has_breakpoint(key_path):
-                # We are inside an NXcollection or a group without NX_class.
-                continue  # This continues the outer attr_name loop
+            if self._has_breakpoint_at(path, include_self=True):
+                continue
 
             check_reserved_prefix(full_path, appdef_node.name, "attribute")
 
@@ -771,9 +917,7 @@ def validate_hdf_group_against(
                 return
 
             if node is None:
-                # Only report undocumented if the parent object is not linked
-                if not ignore_undocumented and full_path.startswith(parent_obj.name):
-                    parent_path = path.strip("/").rsplit("/", 1)[0]
+                if not self._ignore_undocumented and self._is_canonical_path(path):
                     collector.collect_and_log(
                         full_path,
                         ValidationProblem.MissingDocumentation,
@@ -916,25 +1060,51 @@ def validate_hdf_group_against(
 
     for req_concept in sorted(required_entities):
         # Skip if the entire group is missing
-        if any(req_concept.startswith(group) for group in required_groups):
-            continue
-        if "@" in req_concept:
-            # Skip if the entire field is missing
-            if any(
-                req_concept.rsplit("@", -1)[0].startswith(group)
-                for group in required_entities
-            ):
+        for req_concept in sorted(self._required_entities):
+            if any(req_concept.startswith(grp) for grp in self._required_groups):
                 continue
-            collector.collect_and_log(
-                f"{entry_name}/{req_concept}",
-                ValidationProblem.MissingRequiredAttribute,
-                None,
-            )
-            continue
-        collector.collect_and_log(
-            f"{entry_name}/{req_concept}", ValidationProblem.MissingRequiredField, None
-        )
+            if "@" in req_concept:
+                if any(
+                    req_concept.rsplit("@", 1)[0].startswith(ent)
+                    for ent in self._required_entities
+                ):
+                    continue
+                collector.collect_and_log(
+                    f"{self._entry_name}/{req_concept}",
+                    ValidationProblem.MissingRequiredAttribute,
+                    None,
+                )
+            else:
+                collector.collect_and_log(
+                    f"{self._entry_name}/{req_concept}",
+                    ValidationProblem.MissingRequiredField,
+                    None,
+                )
 
+        
+
+
+def validate_hdf_group_against(
+    appdef: str,
+    data: h5py.Group,
+    filename: str,
+    ignore_undocumented: bool = False,
+) -> bool:
+    """
+    Validate an HDF5 group against the NeXus tree for the application definition *appdef*.
+
+    Args:
+        appdef: The application definition name.
+        data: The h5py entry group to validate.
+        filename: Path to the HDF5 file (used for link resolution).
+        ignore_undocumented: If True, skip undocumented concepts and only check
+            that required concepts are present.
+
+    Returns:
+        True if the group is valid, False otherwise.
+    """
+    visitor = ValidationVisitor(appdef, data.name, ignore_undocumented)
+    NexusFileHandler(filename).process(visitor)
     return not collector.has_validation_problems()
 
 

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -176,10 +176,21 @@ class ValidationVisitor(NexusVisitor):
     Validate an HDF5 group against the Nexus tree for the application definition `appdef`.
 
     Implements :class:`~pynxtools.nexus.handler.NexusVisitor` so it can be
-    driven by :class:`~pynxtools.nexus.handler.NexusFileHandler`.
+    driven by :class:`~pynxtools.nexus.handler.NexusFileHandler`.  File
+    traversal (including link resolution) is fully delegated to the handler;
+    this class only contains schema-resolution and problem-collection logic.
 
-    Encapsulates all schema resolution and required-concept tracking that was
-    previously implemented as closures inside ``validate_hdf_group_against``.
+    Hook responsibilities:
+
+    * ``on_group`` - validates the group's NX_class and required child concepts;
+      skips nodes outside the target entry.
+    * ``on_field`` - validates type, unit, enum, and NXdata constraints.
+    * ``on_attribute`` - validates attribute type and enum membership.
+    * ``on_complete`` - emits ``MissingRequired*`` problems for every required
+      concept not encountered during traversal.
+    * ``on_broken_link`` - emits a ``BrokenLink`` problem for soft or external
+      links whose target cannot be resolved.  The link type (``h5py.SoftLink``
+      vs ``h5py.ExternalLink``) is available via the *link* argument.
 
     Usage::
 
@@ -267,6 +278,18 @@ class ValidationVisitor(NexusVisitor):
     def on_complete(self, root: h5py.File) -> None:
         """Emit validation errors for all required concepts not encountered."""
         self._report_missing()
+
+    def on_broken_link(self, hdf_path: str, link) -> None:
+        """Log a broken soft or external link as a validation problem."""
+        rel = self._entry_relative(hdf_path)
+        if rel is None:
+            return
+        target = getattr(link, "path", str(link))
+        collector.collect_and_log(
+            f"{self._entry_name}/{rel}",
+            ValidationProblem.BrokenLink,
+            target,
+        )
 
     def _entry_relative(self, hdf_path: str) -> str | None:
         """Return *hdf_path* relative to this entry, or ``None`` if outside.
@@ -498,6 +521,7 @@ class ValidationVisitor(NexusVisitor):
         required_entities.update(required_sub_entities)
 
     def _variadic_node_exists_for(
+        self,
         path: str,
         variadic_name: str,
         node_type: Literal["group", "field", "attribute"] | None = None,
@@ -604,14 +628,9 @@ class ValidationVisitor(NexusVisitor):
     # ------------------------------------------------------------------
 
     def _is_canonical_path(self, rel_path: str) -> bool:
-        """Return ``True`` if *rel_path* does not pass through any soft link
-        ancestor.
+        """Return ``True`` if *rel_path* does not pass through any soft link ancestor.
 
-        When a node is reached via a soft link ancestor, the HDF5 ``.name``
-        property and the logical path are the same (h5py uses the access path).
-        This helper detects link-based paths so that undocumented-node warnings
-        are suppressed for nodes that are only visible through a link — matching
-        the behavior of the old ``_visititems`` implementation.
+        Suppresses undocumented-node warnings for nodes reachable only via a link.
         """
         if self._data is None:
             return True
@@ -944,102 +963,8 @@ class ValidationVisitor(NexusVisitor):
                 node.items,
                 node.open_enum,
                 full_path,
-                data,
+                parent_obj,
             )
-
-    def validate(path: str, h5_obj: h5py.Group | h5py.Dataset):
-        """
-        Dispatch validation for either groups or fields based on object type.
-
-        Args:
-            path (str): Path to the object.
-            h5_obj (Union[h5py.Group, h5py.Dataset]): The HDF5 object to validate.
-        """
-        if isinstance(h5_obj, h5py.Group):
-            handle_group(path, h5_obj)
-        elif isinstance(h5_obj, h5py.Dataset):
-            handle_field(path, h5_obj)
-            check_reserved_suffix(f"{entry_name}/{path}", h5_obj.parent)
-        handle_attributes(path, h5_obj.attrs, h5_obj)
-
-    def visititems(group: h5py.Group, path: str = "", filename: str = ""):
-        """
-        Recursively visit all items in a group and apply validation.
-
-        Args:
-            group (h5py.Group): The group to walk.
-            path (str, optional): Current HDF5 path.
-            filename (str, optional): Name of the file for resolving links.
-        """
-        for group_name in group:
-            full_path = f"{path}/{group_name}".lstrip("/")
-            link = group.get(group_name, getlink=True)
-            if isinstance(link, h5py.SoftLink):
-                target_path = link.path
-
-                if "target" not in group[group_name].attrs:
-                    collector.collect_and_log(
-                        f"{entry_name}/{full_path}",
-                        ValidationProblem.MissingTargetAttribute,
-                        None,
-                    )
-                else:
-                    attr_target = group[group_name].attrs["target"]
-                    if attr_target != target_path:
-                        collector.collect_and_log(
-                            f"{entry_name}/{full_path}",
-                            ValidationProblem.TargetAttributeMismatch,
-                            attr_target,
-                            target_path,
-                        )
-
-                # Resolve target relative to the link location
-                if target_path.startswith(entry_name):
-                    if target_path not in data:
-                        collector.collect_and_log(
-                            path, ValidationProblem.BrokenLink, target_path
-                        )
-                        continue
-                    resolved_obj = data[target_path]
-                    validate(full_path, resolved_obj)
-                    if isinstance(resolved_obj, h5py.Group):
-                        # recurse into subgroups
-                        visititems(resolved_obj, full_path, filename)
-                else:
-                    with h5py.File(filename, "r") as h5file:
-                        if target_path not in h5file:
-                            collector.collect_and_log(
-                                path, ValidationProblem.BrokenLink, target_path
-                            )
-                            continue
-                        resolved_obj = h5file[target_path]
-                        validate(full_path, resolved_obj)
-                        if isinstance(resolved_obj, h5py.Group):
-                            # recurse into subgroups
-                            visititems(resolved_obj, full_path, filename)
-
-            elif isinstance(link, h5py.ExternalLink):
-                filename = link.filename
-                target_path = link.path
-                # Open external file and validate
-                with h5py.File(filename, "r") as ext_file:
-                    if target_path not in ext_file:
-                        collector.collect_and_log(
-                            path, ValidationProblem.BrokenLink, target_path
-                        )
-                    resolved_obj = ext_file[target_path]
-                    validate(full_path, resolved_obj)
-                    if isinstance(resolved_obj, h5py.Group):
-                        # recurse into subgroups
-                        visititems(resolved_obj, full_path, filename)
-
-            elif isinstance(link, h5py.HardLink):
-                # Validate hard links (normal objects)
-                resolved_obj = group.get(group_name)
-                validate(full_path, resolved_obj)
-                if isinstance(resolved_obj, h5py.Group):
-                    # recurse into subgroups
-                    visititems(resolved_obj, full_path, filename)
 
     collector.clear()
 

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -1192,21 +1192,26 @@ def validate_dict_against(
         resolved_keys = copy.deepcopy(keys)
         for key, value in keys.copy().items():
             if isinstance(value, dict) and "link" in value:
+                link_value = value["link"]
+                key_path = f"{prev_path}/{key}" if prev_path else key
+
+                # Virtual datasets: link is a list of "filepath:hdfpath" sources.
+                # The VDS assembly is performed by the writer; nothing to resolve here.
+                if isinstance(link_value, list):
+                    continue
+
                 link_key = None  # Track is linked path exists
                 file_path = None
-                if re_groups := re.match(
-                    r"^(.+\.(?:nxs|h5|hdf5)):(.+)$", value["link"]
-                ):
+                if re_groups := re.match(r"^(.+\.(?:nxs|h5|hdf5)):(.+)$", link_value):
                     file_path, link_path = re_groups.groups()[0:2]
                 else:
-                    link_path = value["link"]
+                    link_path = link_value
 
                 # Allow link path with and without leading /
                 link_path = link_path[1:] if link_path.startswith("/") else link_path
 
-                key_path = f"{prev_path}/{key}" if prev_path else key
                 # External link resolution (file_path:link_path)
-                if ":" in value["link"]:
+                if ":" in link_value:
 
                     def get_node(_, obj):
                         if obj.name[1:] == link_path:
@@ -1582,12 +1587,11 @@ def validate_dict_against(
                                 )
                             return None
                     return node
-        # Variadic branch: filter to candidates whose concept name matches, then
-        # use the shared scoreboard selection (same logic as NexusNode.best_child_for).
+        # Variadic branch: a concept-name prefix is required to identify which
+        # variadic schema node to match against.  Keys without a prefix (e.g. plain
+        # "internal_link") must not match variadic schema nodes.
         variadic_candidates = [
-            n
-            for n in nodes
-            if n.variadic and (not concept_name or n.name == concept_name)
+            n for n in nodes if n.variadic and concept_name and n.name == concept_name
         ]
         return _select_best_namefit(instance_name, variadic_candidates)
 

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -173,7 +173,7 @@ def is_valid_unit_for_node(
 
 class ValidationVisitor(NexusVisitor):
     """
-    Validate an HDF5 group against the Nexus tree for the application definition `appdef`.
+    Validate an HDF5 entry group against a NeXus application definition.
 
     Implements :class:`~pynxtools.nexus.handler.NexusVisitor` so it can be
     driven by :class:`~pynxtools.nexus.handler.NexusFileHandler`.  File
@@ -367,7 +367,7 @@ class ValidationVisitor(NexusVisitor):
         if not nodes:
             return None
 
-        best_match = None
+        best_match: NexusNode | None = None
         best_score = -1
 
         # use score as key for the outer dict and inner dict as value with
@@ -421,84 +421,78 @@ class ValidationVisitor(NexusVisitor):
 
         return best_match
 
-    # Only cache based on path. That way we retain the nx_class information
-    # in the tree
-    # Allow for 10000 cache entries. This should be enough for most cases
-    @cached(
-        cache=LRUCache(maxsize=10000),
-        key=lambda path, node_type=None, nx_class=None, hint=None: hashkey(path),
-    )
-    def find_node_for(
+    def _find_node_for(
+        self,
         path: str,
         node_type: Literal["group", "field", "attribute"] | None = None,
         nx_class: str | None = None,
         hint: Literal["axis", "signal"] | None = None,
     ) -> NexusNode | None:
         """
-        Find the NexusNode for a given HDF5 path, optionally constrained by node type and NX_class.
+        Find the NexusNode for *path*, cached by path only.
 
-        Uses caching for performance.
-
-        Args:
-            path (str): The HDF5 path.
-            node_type (Optional[str]): Node type filter: 'group', 'field', or 'attribute'.
-            nx_class (Optional[str]): NX_class to restrict search for groups.
-
-        Returns:
-            Optional[NexusNode]: Matching node, or None if no match found.
+        Raises:
+            TypeError: If the path matches a concept of a conflicting type.
         """
+        cached = self._node_cache.get(path, self._MISSING)
+        if cached is not self._MISSING:
+            return cached  # type: ignore[return-value]
+
         if path == "":
-            return tree
+            return self._tree
 
-        possible_node_types = ["group", "field", "attribute"]
+        *prev_parts, last_elem = path.rsplit("/", 1)
+        parent = (
+            self._find_node_for(prev_parts[0], hint=hint) if prev_parts else self._tree
+        )
+        parent_copy = copy.copy(parent)
 
-        *prev_path, last_elem = path.rsplit("/", 1)
-
-        node = find_node_for(prev_path[0], hint=hint) if prev_path else tree
-        current = copy.copy(node)
-
-        if node is None:
+        if parent is None:
+            self._node_cache[path] = None
             return None
 
         children_to_check = [
-            node.search_add_child_for(child)
-            for child in node.get_all_direct_children_names(
+            parent.search_add_child_for(child)
+            for child in parent.get_all_direct_children_names(
                 nx_class=nx_class, node_type=node_type
             )
         ]
-        node = best_namefit_of(last_elem, children_to_check, hint)
+        node = self._best_namefit_of(last_elem, children_to_check, hint)
 
         if node is None:
-            # Check that there is no other node with the same name, but a different type
-            other_node_types = [nt for nt in possible_node_types if nt != node_type]
-
+            other_node_types = [
+                nt for nt in self._POSSIBLE_NODE_TYPES if nt != node_type
+            ]
             for other_node_type in other_node_types:
-                children_to_check = [
-                    current.search_add_child_for(child)
-                    for child in current.get_all_direct_children_names(
-                        node_type=other_node_type,
-                        nx_class=nx_class,
+                other_children = [
+                    parent_copy.search_add_child_for(child)
+                    for child in parent_copy.get_all_direct_children_names(
+                        node_type=other_node_type, nx_class=nx_class
                     )
                 ]
-                other_node = best_namefit_of(last_elem, children_to_check)
-                if other_node is not None:
-                    if not other_node.variadic:
-                        collector.collect_and_log(
-                            path,
-                            ValidationProblem.InvalidNexusTypeForNamedConcept,
-                            other_node,
-                            node_type,
-                        )
-                        raise TypeError(
-                            f"The type ('{node_type}') of {path} conflicts with another existing concept "
-                            f"{other_node.get_path()} (which is of type '{other_node.nx_type}'."
-                        )
-
+                other_node = self._best_namefit_of(last_elem, other_children)
+                if other_node is not None and not other_node.variadic:
+                    collector.collect_and_log(
+                        path,
+                        ValidationProblem.InvalidNexusTypeForNamedConcept,
+                        other_node,
+                        node_type,
+                    )
+                    raise TypeError(
+                        f"The type ('{node_type}') of {path} conflicts with another existing "
+                        f"concept {other_node.get_path()} (which is of type '{other_node.nx_type}')."
+                    )
+            self._node_cache[path] = None
             return None
 
+        self._node_cache[path] = node
         return node
 
-    def update_required_concepts(path: str, node: NexusNode):
+    # ------------------------------------------------------------------
+    # Required-concept tracking
+    # ------------------------------------------------------------------
+
+    def _update_required_concepts(self, path: str, node: NexusNode) -> None:
         """
         Update the sets of required groups and entities based on the current node.
 
@@ -508,17 +502,14 @@ class ValidationVisitor(NexusVisitor):
         """
         prefix = f"{path}/" if path else ""
 
-        required_subgroups = [
+        self._required_groups.update(
             f"{prefix}{grp.lstrip('/')}"
             for grp in node.required_groups(recurse_children=False)
-        ]
-        required_sub_entities = [
+        )
+        self._required_entities.update(
             f"{prefix}{ent.lstrip('/')}"
             for ent in node.required_fields_and_attrs_names(recurse_children=False)
-        ]
-
-        required_groups.update(required_subgroups)
-        required_entities.update(required_sub_entities)
+        )
 
     def _variadic_node_exists_for(
         self,
@@ -538,61 +529,42 @@ class ValidationVisitor(NexusVisitor):
             bool: True if a matching variadic node exists.
         """
 
-        def _get_parent_path(path: str) -> str:
-            """
-            Return the parent path of a given HDF5 path.
-
-            Args:
-                path (str): A full HDF5 path (e.g., "/entry/sample/temperature").
-
-            Returns:
-                str: The parent path (e.g., "/entry/sample"). If the path has no parent,
-                    returns an empty string.
-
-            Example:
-                >>> _get_parent_path("/entry/sample/temperature")
-                '/entry/sample'
-
-                >>> _get_parent_path("temperature")
-                ''
-
-                >>> _get_parent_path("/temperature")
-                ''
-            """
+        def _parent_of(path: str) -> str:
             if "/" not in path.strip("/"):
                 return ""
             return path.rstrip("/").rsplit("/", 1)[0]
 
-        if _get_parent_path(variadic_name) == _get_parent_path(path):
-            node = find_node_for(variadic_name, node_type=node_type)
-            if node is not None and node.variadic:
-                score = get_nx_namefit(
-                    path.rsplit("/", 1)[-1],
-                    node.name,
-                    node.name_type == "any",
-                    node.name_type == "partial",
-                )
-                if score > -1:
-                    return True
-
+        if _parent_of(variadic_name) != _parent_of(path):
             return False
 
-    def remove_from_req_groups(path: str):
+        node = self._find_node_for(variadic_name, node_type=node_type)
+        if node is not None and node.variadic:
+            score = get_nx_namefit(
+                path.rsplit("/", 1)[-1],
+                node.name,
+                node.name_type == "any",
+                node.name_type == "partial",
+            )
+            if score > -1:
+                return True
+        return False
+
+    def _remove_from_req_groups(self, path: str) -> None:
         """
         Remove a path from the set of required groups, accounting for variadic nodes.
 
         Args:
             path (str): The path to remove.
         """
-        if path in required_groups:
-            required_groups.remove(path)
+        if path in self._required_groups:
+            self._required_groups.remove(path)
         else:
             # Check if a variadic required group exists
-            for grp in list(required_groups):
-                if _variadic_node_exists_for(path, grp, node_type="group"):
-                    required_groups.remove(grp)
+            for grp in list(self._required_groups):
+                if self._variadic_node_exists_for(path, grp, node_type="group"):
+                    self._required_groups.remove(grp)
 
-    def remove_from_req_entities(path: str):
+    def _remove_from_req_entities(self, path: str):
         """
         Remove a path from the set of required entities (fields/attributes),
         accounting for variadic nodes.
@@ -600,8 +572,8 @@ class ValidationVisitor(NexusVisitor):
         Args:
             path (str): The path to remove.
         """
-        if path in required_entities:
-            required_entities.remove(path)
+        if path in self._required_entities:
+            self._required_entities.remove(path)
         else:
             for ent in list(self._required_entities):
                 node_type: Literal["attribute", "field"] = (
@@ -617,11 +589,10 @@ class ValidationVisitor(NexusVisitor):
                     if path.endswith("@units") and ent.endswith("@units")
                     else ent
                 )
-
-                if _variadic_node_exists_for(
+                if self._variadic_node_exists_for(
                     clean_path, clean_ent, node_type=node_type
                 ):
-                    required_entities.remove(ent)
+                    self._required_entities.remove(ent)
 
     # ------------------------------------------------------------------
     # HDF5 handlers
@@ -684,7 +655,7 @@ class ValidationVisitor(NexusVisitor):
                 return True
         return False
 
-    def handle_group(path: str, group: h5py.Group):
+    def _handle_group(self, path: str, group: h5py.Group) -> None:
         """
         Handle validation logic for HDF5 groups.
 
@@ -692,9 +663,8 @@ class ValidationVisitor(NexusVisitor):
             path (str): Relative HDF5 path to the group.
             group (h5py.Group): The group object.
         """
-        full_path = f"{entry_name}/{path}"
-
-        check_reserved_prefix(full_path, appdef_node.name, "group")
+        full_path = f"{self._entry_name}/{path}"
+        check_reserved_prefix(full_path, self._appdef_node.name, "group")
 
         if not group.attrs.get("NX_class"):
             if not self._ignore_undocumented and self._is_canonical_path(path):
@@ -704,11 +674,12 @@ class ValidationVisitor(NexusVisitor):
             return
 
         try:
-            node = find_node_for(
+            node = self._find_node_for(
                 path, node_type="group", nx_class=group.attrs.get("NX_class")
             )
         except TypeError:
             return
+
         if node is None:
             if not self._ignore_undocumented and self._is_canonical_path(path):
                 collector.collect_and_log(
@@ -718,104 +689,77 @@ class ValidationVisitor(NexusVisitor):
 
         if node.nx_type != "group":
             # In case a field was accidentally linked to a group.
-            collector.collect_and_log(
-                full_path,
-                ValidationProblem.ExpectedField,
-                None,
-            )
+            collector.collect_and_log(full_path, ValidationProblem.ExpectedField, None)
             return
 
-        update_required_concepts(path, node)
-        remove_from_req_groups(path)
+        self._update_required_concepts(path, node)
+        self._remove_from_req_groups(path)
 
-        if _check_for_nxcollection_parent(node):
+        if node.has_nxcollection_parent():
             # NXcollection found in parents, stop checking
             return
 
         if node.nx_class == "NXdata":
-            handle_nxdata(path, group)
+            self._handle_nxdata(path, group)
         if node.nx_class == "NXcollection":
             return
 
-    def handle_nxdata(path: str, group: h5py.Group):
-        """
-        Handle validation of NXdata groups, including signal, axes, and auxiliary signals.
-
-        Args:
-            path (str): HDF5 path to the NXdata group.
-            group (h5py.Group): The NXdata group object.
-        """
-        full_path = f"{entry_name}/{path}"
-
-        def check_nxdata():
-            data_field = group.get(signal)
-
-            if data_field is None:
-                collector.collect_and_log(
-                    f"{full_path}/{signal}",
-                    ValidationProblem.NXdataMissingSignalData,
-                    None,
-                )
-            else:
-                handle_field(f"{path}/{signal}", data_field, hint="signal")
-
-            # check NXdata attributes
-            attrs = ("signal", "auxiliary_signals", "axes")
-            data_attrs = {k: group.attrs[k] for k in attrs if k in group.attrs}
-
-            handle_attributes(path, data_attrs, group)
-
-            for i, axis in enumerate(axes):
-                if axis == ".":
-                    continue
-                index = group.get(f"{axis}_indices", i)
-
-                axis_field = group.get(axis)
-
-                if axis_field is None:
-                    collector.collect_and_log(
-                        f"{full_path}/{axis}",
-                        ValidationProblem.NXdataMissingAxisData,
-                        None,
-                    )
-                    break
-                else:
-                    handle_field(f"{path}/{axis}", axis_field, hint="axis")
-                if np.shape(data_field)[index] != len(axis_field):
-                    collector.collect_and_log(
-                        f"{path}/{axis}",
-                        ValidationProblem.NXdataAxisMismatch,
-                        f"{full_path}/{signal}",
-                        index,
-                    )
-
+    def _handle_nxdata(self, path: str, group: h5py.Group) -> None:
+        """Validate an NXdata group: signal, axes, and NXdata-specific attributes."""
+        full_path = f"{self._entry_name}/{path}"
         signal = group.attrs.get("signal")
         aux_signals = group.attrs.get("auxiliary_signals", [])
         axes = group.attrs.get("axes", [])
-
         if isinstance(axes, str):
             axes = [axes]
 
-        indices = map(lambda x: f"{x}_indices", axes)
-        errors = map(lambda x: f"{x}_errors", [signal, *aux_signals, *axes])
+        if signal is None:
+            return
 
-        # TODO: check that the indices match
-        # TODO: check that the errors have the same dim as the fields
+        data_field = group.get(signal)
+        if data_field is None:
+            collector.collect_and_log(
+                f"{full_path}/{signal}", ValidationProblem.NXdataMissingSignalData, None
+            )
+        else:
+            self._handle_field(f"{path}/{signal}", data_field, hint="signal")
 
-        if signal is not None:
-            check_nxdata()
+        nxdata_attr_names = ("signal", "auxiliary_signals", "axes")
+        data_attrs = {k: group.attrs[k] for k in nxdata_attr_names if k in group.attrs}
+        self._handle_attributes(path, data_attrs, group)
 
-    def handle_field(
+        for i, axis in enumerate(axes):
+            if axis == ".":
+                continue
+            index = group.get(f"{axis}_indices", i)
+            axis_field = group.get(axis)
+            if axis_field is None:
+                collector.collect_and_log(
+                    f"{full_path}/{axis}", ValidationProblem.NXdataMissingAxisData, None
+                )
+                break
+            else:
+                self._handle_field(f"{path}/{axis}", axis_field, hint="axis")
+            if np.shape(data_field)[index] != len(axis_field):
+                collector.collect_and_log(
+                    f"{path}/{axis}",
+                    ValidationProblem.NXdataAxisMismatch,
+                    f"{full_path}/{signal}",
+                    index,
+                )
+
+    def _handle_field(
+        self,
         path: str,
         dataset: h5py.Dataset,
         hint: Literal["axis", "signal"] | None = None,
     ) -> None:
         """
         Validate an HDF5 dataset (NeXus field) against the schema tree.
-        
+
         Args:
             path (str): Path to the dataset.
-            data (h5py.Dataset): Dataset object.
+            dataset (h5py.Dataset): Dataset object.
             hint (str):
                 If the field is in an NXdata group, this is used to figure out
                 if it is an AXISNAME or a DATA.
@@ -825,10 +769,10 @@ class ValidationVisitor(NexusVisitor):
         if self._has_breakpoint_at(path):
             return
 
-        check_reserved_prefix(full_path, appdef_node.name, "field")
+        check_reserved_prefix(full_path, self._appdef_node.name, "field")
 
         try:
-            node = find_node_for(path, node_type="field", hint=hint)
+            node = self._find_node_for(path, node_type="field", hint=hint)
         except TypeError:
             return
 
@@ -848,10 +792,10 @@ class ValidationVisitor(NexusVisitor):
             )
             return
 
-        update_required_concepts(path, node)
-        remove_from_req_entities(path)
+        self._update_required_concepts(path, node)
+        self._remove_from_req_entities(path)
 
-        if _check_for_nxcollection_parent(node):
+        if node.has_nxcollection_parent():
             # NXcollection found in parents, stop checking
             return
 
@@ -866,30 +810,26 @@ class ValidationVisitor(NexusVisitor):
             node.items,
             node.open_enum,
             full_path,
-            data,
+            self._data,
         )
 
         units = dataset.attrs.get("units")
         units_path = f"{full_path}/@units"
         if node.unit is not None:
-            remove_from_req_entities(f"{path}/@units")
-
+            self._remove_from_req_entities(f"{path}/@units")
             if node.unit != "NX_UNITLESS":
                 if units is None:
                     collector.collect_and_log(
                         full_path, ValidationProblem.MissingUnit, node.unit
                     )
                     return
+            hints: dict[str, Any] = {}
             # Special case: NX_TRANSFORMATION unit depends on `@transformation_type` attribute
             if (
                 transformation_type := dataset.attrs.get("transformation_type")
             ) is not None:
                 hints = {"transformation_type": transformation_type}
-            else:
-                hints = {}
-
             is_valid_unit_for_node(node, units, units_path, hints)
-
         elif units is not None:
             if not self._ignore_undocumented and self._is_canonical_path(path):
                 collector.collect_and_log(
@@ -898,11 +838,12 @@ class ValidationVisitor(NexusVisitor):
                     units,
                 )
 
-    def handle_attributes(
+    def _handle_attributes(
+        self,
         path: str,
         attrs: h5py.AttributeManager,
         parent_obj: h5py.Group | h5py.Dataset,
-    ):
+    ) -> None:
         """
         Validate attributes on a given HDF5 object.
 
@@ -912,14 +853,7 @@ class ValidationVisitor(NexusVisitor):
             parent_obj (Union[h5py.Group, h5py.Dataset])): Parent object of these attributes.
         """
         for attr_name in attrs:
-            full_path = f"{entry_name}/{path}/@{attr_name}"
-
-            if attr_name in (
-                "NX_class",
-                "units",
-                "target",
-                "custom",
-            ) or attr_name.endswith("_custom"):
+            if attr_name in self._SKIP_ATTRS or attr_name.endswith("_custom"):
                 # Ignore special attrs
                 continue
 
@@ -928,10 +862,10 @@ class ValidationVisitor(NexusVisitor):
             if self._has_breakpoint_at(path, include_self=True):
                 continue
 
-            check_reserved_prefix(full_path, appdef_node.name, "attribute")
+            check_reserved_prefix(full_path, self._appdef_node.name, "attribute")
 
             try:
-                node = find_node_for(f"{path}/{attr_name}", node_type="attribute")
+                node = self._find_node_for(f"{path}/{attr_name}", node_type="attribute")
             except TypeError:
                 return
 
@@ -944,9 +878,9 @@ class ValidationVisitor(NexusVisitor):
                     )
                 continue
 
-            remove_from_req_entities(f"{path}/@{attr_name}")
+            self._remove_from_req_entities(f"{path}/@{attr_name}")
 
-            if _check_for_nxcollection_parent(node):
+            if node.has_nxcollection_parent():
                 # NXcollection found in parents, stop checking
                 return
 
@@ -966,25 +900,15 @@ class ValidationVisitor(NexusVisitor):
                 parent_obj,
             )
 
-    collector.clear()
+    def _report_missing(self) -> None:
+        """Emit validation problems for all required concepts not found during traversal."""
+        for req_concept in sorted(self._required_groups):
+            collector.collect_and_log(
+                f"{self._entry_name}/{req_concept}",
+                ValidationProblem.MissingRequiredGroup,
+                None,
+            )
 
-    appdef_node = generate_tree_from(appdef)
-    tree = appdef_node.search_add_child_for("ENTRY")
-    entry_name = data.name
-
-    required_groups: set[str] = set()
-    required_entities: set[str] = set()
-    update_required_concepts("", tree)
-
-    visititems(data, filename=filename)
-
-    for req_concept in sorted(required_groups):
-        collector.collect_and_log(
-            f"{entry_name}/{req_concept}", ValidationProblem.MissingRequiredGroup, None
-        )
-
-    for req_concept in sorted(required_entities):
-        # Skip if the entire group is missing
         for req_concept in sorted(self._required_entities):
             if any(req_concept.startswith(grp) for grp in self._required_groups):
                 continue
@@ -1005,8 +929,6 @@ class ValidationVisitor(NexusVisitor):
                     ValidationProblem.MissingRequiredField,
                     None,
                 )
-
-        
 
 
 def validate_hdf_group_against(

--- a/src/pynxtools/nexus/handler.py
+++ b/src/pynxtools/nexus/handler.py
@@ -309,12 +309,12 @@ class NexusFileHandler:
         # soft links and external links can be dispatched to the visitor rather
         # than crashing (h5py returns None for a broken soft link in .items()).
         if isinstance(hdf_node, h5py.Group):
-            for ch_name in hdf_node:
-                full_name = ch_name if not name else f"{name}/{ch_name}"
-                link = hdf_node.get(ch_name, getlink=True)
+            for child_name in hdf_node:
+                full_name = child_name if not name else f"{name}/{child_name}"
+                link = hdf_node.get(child_name, getlink=True)
 
                 if isinstance(link, h5py.SoftLink):
-                    child = hdf_node.get(ch_name)  # None when target is missing
+                    child = hdf_node.get(child_name)  # None when target is missing
                     if child is None:
                         visitor.on_broken_link(full_name, link)
                         continue
@@ -326,6 +326,6 @@ class NexusFileHandler:
                     self._traverse_external(full_name, link, visitor)
 
                 else:  # HardLink (or any future link type)
-                    child = hdf_node[ch_name]
+                    child = hdf_node[child_name]
                     if self._not_yet_visited(root, full_name):
                         self._full_visit(root, child, full_name, visitor)

--- a/src/pynxtools/nexus/handler.py
+++ b/src/pynxtools/nexus/handler.py
@@ -24,7 +24,7 @@ supplying the right visitor; the handler owns only traversal and file I/O.
 
 Visitor interface
 -----------------
-Every visitor implements the same set of typed hooks:
+Every visitor must implement four abstract hooks:
 
 * ``on_group(hdf_path, hdf_node)`` - called for every HDF5 group, including the
   root (whose *hdf_path* is an empty string ``""``).
@@ -33,6 +33,29 @@ Every visitor implements the same set of typed hooks:
   attribute of every group and dataset, **after** the node itself has been
   dispatched.
 * ``on_complete(root)`` - called once after the full traversal.
+
+Two optional hooks have default no-op implementations and may be overridden:
+
+* ``on_broken_link(hdf_path, link)`` - called when a soft or external link
+  cannot be resolved (target missing or external file unreachable).  The broken
+  node is skipped; traversal continues with the next sibling.
+* ``on_external_link(hdf_path, link)`` - called when an external link is first
+  encountered, *before* the handler opens the external file and recurses into
+  its target subtree.  Nodes from the external subtree are visited with the same
+  *hdf_path* prefix as the link itself (e.g. a link at ``"entry/ext"`` whose
+  target is a group with child ``"value"`` results in a call
+  ``on_field("entry/ext/value", ...)``).
+
+Link traversal
+--------------
+* **Soft links** - resolved via ``h5py``; broken links dispatch ``on_broken_link``
+  and are otherwise skipped.
+* **Hard links** - followed transparently; a cycle guard prevents infinite
+  recursion when a hard-linked descendant is an ancestor of itself.
+* **External links** - the external file is opened in a separate ``h5py.File``
+  context; broken external links dispatch ``on_broken_link`` and are skipped.
+  If a visitor needs to distinguish broken soft links from broken external links
+  it can inspect the type of the *link* argument passed to ``on_broken_link``.
 
 Supported visitor use-cases:
 
@@ -64,16 +87,25 @@ class NexusVisitor(ABC):
     """
     Abstract base class for NeXus file visitors.
 
-    Subclasses must implement all four hooks. Hooks that are not meaningful for
-    a given visitor should be implemented as ``pass``.
+    Subclasses must implement the four abstract hooks below.  Hooks that are not
+    meaningful for a given visitor should be implemented as ``pass``.  Two
+    additional optional hooks (``on_broken_link``, ``on_external_link``) have
+    default no-op implementations and may be overridden as needed.
 
     Hook call order for each node:
 
     1. ``on_group`` **or** ``on_field`` (dispatched by node type)
     2. ``on_attribute`` for every attribute of that node (in iteration order)
+    3. Recursion into children (groups only)
 
-    Root is treated as a group with *hdf_path* equal to ``""``.
-    After full traversal, ``on_complete`` is called with the open root file.
+    Special cases:
+
+    * Root is treated as a group with *hdf_path* equal to ``""``.
+    * Broken soft/external links dispatch ``on_broken_link`` instead of the
+      normal group/field hook; the node is then skipped.
+    * External links additionally dispatch ``on_external_link`` *before*
+      the handler opens the external file.
+    * After the full traversal, ``on_complete`` is called with the open root.
     """
 
     @abstractmethod
@@ -117,6 +149,28 @@ class NexusVisitor(ABC):
     @abstractmethod
     def on_complete(self, root: h5py.File) -> None:
         """Called once after the full traversal, before the file is closed."""
+
+    def on_broken_link(
+        self,
+        hdf_path: str,
+        link: h5py.SoftLink | h5py.ExternalLink,
+    ) -> None:
+        """Called when a soft or external link cannot be resolved.
+
+        The default implementation does nothing.  Override in visitors that
+        need to report broken links (e.g. ``ValidationVisitor``).
+        """
+
+    def on_external_link(
+        self,
+        hdf_path: str,
+        link: h5py.ExternalLink,
+    ) -> None:
+        """Called when an external link is first encountered, before the handler
+        attempts to open the external file and recurse into it.
+
+        The default implementation does nothing.
+        """
 
 
 class NexusFileHandler:
@@ -187,6 +241,9 @@ class NexusFileHandler:
         """Return ``True`` if *name* is not an alias of an ancestor on the same path.
 
         Detects HDF5 hard links that would otherwise cause infinite recursion.
+        When traversing an external file the path names are relative to the main
+        file, so the ancestor paths may not exist in *root* — in that case the
+        paths are definitely not cycles and the method returns ``True``.
         """
         parts = name.split("/")
         for idx in range(1, len(parts)):
@@ -194,6 +251,31 @@ class NexusFileHandler:
             if root["/" + ancestor] == root["/" + name]:
                 return False
         return True
+
+    def _traverse_external(
+        self,
+        hdf_path: str,
+        link: h5py.ExternalLink,
+        visitor: NexusVisitor,
+    ) -> None:
+        """Open *link*'s target file and recursively visit its subtree.
+
+        If the external file cannot be opened (missing, wrong format, etc.) the
+        visitor's ``on_broken_link`` hook is called and traversal is skipped.
+        """
+        try:
+            ext_root = h5py.File(link.filename, "r")
+        except Exception:
+            visitor.on_broken_link(hdf_path, link)
+            return
+        try:
+            target = ext_root.get(link.path)
+            if target is None:
+                visitor.on_broken_link(hdf_path, link)
+                return
+            self._full_visit(ext_root, target, hdf_path, visitor)
+        finally:
+            ext_root.close()
 
     def _full_visit(
         self,
@@ -220,9 +302,35 @@ class NexusFileHandler:
         for attr_name, attr_value in hdf_node.attrs.items():
             visitor.on_attribute(name, attr_name, attr_value, hdf_node)
 
-        # Recurse into children
+        # Recurse into children — inspect link types explicitly so that broken
+        # soft links and external links can be dispatched to the visitor rather
+        # than crashing (h5py returns None for a broken soft link in .items()).
         if isinstance(hdf_node, h5py.Group):
-            for ch_name, child in hdf_node.items():
+            for ch_name in hdf_node:
                 full_name = ch_name if not name else f"{name}/{ch_name}"
+<<<<<<< HEAD
                 if self._not_yet_visited(root, full_name):
                     self._full_visit(root, child, full_name, visitor)
+=======
+                link = hdf_node.get(ch_name, getlink=True)
+
+                if isinstance(link, h5py.SoftLink):
+                    child = hdf_node.get(ch_name)  # None when target is missing
+                    if child is None:
+                        visitor.on_broken_link(full_name, link)
+                        continue
+                    if self._not_yet_visited(root, full_name):
+                        self._full_visit(root, child, full_name, visitor)
+
+                elif isinstance(link, h5py.ExternalLink):
+                    visitor.on_external_link(full_name, link)
+                    self._traverse_external(full_name, link, visitor)
+
+                else:  # HardLink (or any future link type)
+<<<<<<< HEAD
+=======
+                    child = hdf_node[ch_name]
+>>>>>>> 2778d996 (allow handling of external and soft links)
+                    if self._not_yet_visited(root, full_name):
+                        self._full_visit(root, child, full_name, visitor)
+>>>>>>> 65db1f12 (allow handling of external and soft links)

--- a/src/pynxtools/nexus/handler.py
+++ b/src/pynxtools/nexus/handler.py
@@ -327,10 +327,7 @@ class NexusFileHandler:
                     self._traverse_external(full_name, link, visitor)
 
                 else:  # HardLink (or any future link type)
-<<<<<<< HEAD
-=======
                     child = hdf_node[ch_name]
->>>>>>> 2778d996 (allow handling of external and soft links)
                     if self._not_yet_visited(root, full_name):
                         self._full_visit(root, child, full_name, visitor)
 >>>>>>> 65db1f12 (allow handling of external and soft links)

--- a/src/pynxtools/nexus/handler.py
+++ b/src/pynxtools/nexus/handler.py
@@ -248,8 +248,11 @@ class NexusFileHandler:
         parts = name.split("/")
         for idx in range(1, len(parts)):
             ancestor = "/".join(parts[:idx])
-            if root["/" + ancestor] == root["/" + name]:
-                return False
+            try:
+                if root["/" + ancestor] == root["/" + name]:
+                    return False
+            except (KeyError, ValueError):
+                pass
         return True
 
     def _traverse_external(
@@ -308,10 +311,6 @@ class NexusFileHandler:
         if isinstance(hdf_node, h5py.Group):
             for ch_name in hdf_node:
                 full_name = ch_name if not name else f"{name}/{ch_name}"
-<<<<<<< HEAD
-                if self._not_yet_visited(root, full_name):
-                    self._full_visit(root, child, full_name, visitor)
-=======
                 link = hdf_node.get(ch_name, getlink=True)
 
                 if isinstance(link, h5py.SoftLink):
@@ -330,4 +329,3 @@ class NexusFileHandler:
                     child = hdf_node[ch_name]
                     if self._not_yet_visited(root, full_name):
                         self._full_visit(root, child, full_name, visitor)
->>>>>>> 65db1f12 (allow handling of external and soft links)

--- a/src/pynxtools/nexus/nexus_tree.py
+++ b/src/pynxtools/nexus/nexus_tree.py
@@ -151,9 +151,9 @@ def _xml_path_in_nxdl(elem: ET._Element) -> str:
 
 def _select_best_namefit(
     name: str,
-    nodes: list["NexusNode"],
+    nodes: list["NexusNode"],  # TODO: list[NexusNode] when py3.10 support is deprecated
     hint: str | None = None,
-) -> Optional["NexusNode"]:
+) -> Optional["NexusNode"]:  # TODO: NexusNode | None when py3.10 support is deprecated
     """Select the best-fitting variadic NexusNode for an HDF5 node named *name*.
 
     Scores each node in *nodes* with :func:`get_nx_namefit` and returns the
@@ -189,7 +189,7 @@ def _select_best_namefit(
 
         if score not in score_board:
             score_board[score] = {"required": [], "recommended": [], "optional": []}
-        for constraint in ("optional", "required", "recommended"):
+        for constraint in ("required", "recommended", "optional"):
             if node.optionality == constraint:
                 score_board[score][constraint].append(idx)
                 break
@@ -645,7 +645,7 @@ class NexusNode(NodeMixin):
             if node is not None and not node.variadic and name == node.name:
                 return node
 
-        variadic = [n for n in children if n is not None and n.variadic]
+        variadic = [node for node in children if node is not None and node.variadic]
         return _select_best_namefit(name, variadic, hint)
 
     def get_docstring(self, depth: int | None = None) -> dict[str, str]:

--- a/src/pynxtools/nexus/nexus_tree.py
+++ b/src/pynxtools/nexus/nexus_tree.py
@@ -149,6 +149,66 @@ def _xml_path_in_nxdl(elem: ET._Element) -> str:
     return "/" + "/".join(reversed(parts)) if parts else ""
 
 
+def _select_best_namefit(
+    name: str,
+    nodes: list["NexusNode"],
+    hint: str | None = None,
+) -> Optional["NexusNode"]:
+    """Select the best-fitting variadic NexusNode for an HDF5 node named *name*.
+
+    Scores each node in *nodes* with :func:`get_nx_namefit` and returns the
+    highest-scoring match.  Logs a debug warning when multiple nodes share the
+    top score under the same optionality constraint, which indicates a schema
+    ambiguity (e.g. two variadic concepts with the same name pattern).
+
+    Args:
+        name: HDF5 node name to fit against the candidates.
+        nodes: Pre-filtered list of variadic :class:`NexusNode` candidates.
+        hint: ``"signal"`` or ``"axis"`` — used to skip ``DATA`` / ``AXISNAME``
+            nodes that don't match the intended role inside an NXdata group.
+
+    Returns:
+        The best-matching :class:`NexusNode`, or ``None`` if no candidate scores
+        above ``-1``.
+    """
+    hint_map: dict[str, str] = {"DATA": "signal", "AXISNAME": "axis"}
+    best_match: NexusNode | None = None
+    best_score = -1
+    score_board: dict[int, dict[str, list[int]]] = {}
+
+    for idx, node in enumerate(nodes):
+        name_any = node.name_type == "any"
+        name_partial = node.name_type == "partial"
+        score = get_nx_namefit(name, node.name, name_any, name_partial)
+
+        if score > best_score:
+            if hint and hint_map.get(node.name) != hint:
+                continue
+            best_match = node
+            best_score = score
+
+        if score not in score_board:
+            score_board[score] = {"required": [], "recommended": [], "optional": []}
+        for constraint in ("optional", "required", "recommended"):
+            if node.optionality == constraint:
+                score_board[score][constraint].append(idx)
+                break
+
+    if score_board:
+        alternative_best_score = max(score_board)
+        if alternative_best_score > -1:
+            for constraint in ("required", "recommended", "optional"):
+                if len(score_board[alternative_best_score][constraint]) > 1:
+                    logger.debug(
+                        f"Multiple best fitting with score {alternative_best_score} found "
+                        f"{[nodes[i].concept_path for i in score_board[alternative_best_score][constraint]]} "
+                        f"constrained by {constraint}; indicates possible issues with nameTyping of "
+                        f"specific NeXus classes/concepts"
+                    )
+
+    return best_match
+
+
 class NexusNode(NodeMixin):
     """
     A NexusNode represents one node in the NeXus tree.
@@ -517,7 +577,11 @@ class NexusNode(NodeMixin):
                 continue
             elif child.nx_type == "field":
                 req_children.append(f"{prev_path}/{child.name}")
-                if isinstance(child, NexusField) and child.unit is not None:
+                if (
+                    isinstance(child, NexusField)
+                    and child.unit is not None
+                    and child.unit != "NX_UNITLESS"
+                ):
                     req_children.append(f"{prev_path}/{child.name}/@units")
             elif child.nx_type == "attribute":
                 req_children.append(f"{prev_path}/@{child.name}")
@@ -570,61 +634,19 @@ class NexusNode(NodeMixin):
         Returns:
             The matching :class:`NexusNode`, or ``None``.
         """
-        hint_map: dict[str, str] = {"DATA": "signal", "AXISNAME": "axis"}
         children = [
             self.search_add_child_for(child)
             for child in self.get_all_direct_children_names(
                 nx_class=nx_class, node_type=node_type
             )
         ]
-        best_match: NexusNode | None = None
-        best_score = -1
-        score_board: dict[int, dict[str, list[int]]] = {}
 
-        for idx, node in enumerate(children):
-            if node is None:
-                continue
-            if not node.variadic:
-                if name == node.name:
-                    return node
-            else:
-                name_any = node.name_type == "any"
-                name_partial = node.name_type == "partial"
-                score = get_nx_namefit(name, node.name, name_any, name_partial)
-                if score > best_score:
-                    if hint and hint_map.get(node.name) != hint:
-                        continue
-                    best_match = node
-                    best_score = score
+        for node in children:
+            if node is not None and not node.variadic and name == node.name:
+                return node
 
-                if score not in score_board:
-                    score_board[score] = {
-                        "required": [],
-                        "recommended": [],
-                        "optional": [],
-                    }
-                for constraint in ["optional", "required", "recommended"]:
-                    # lookup into nodes in decreasing order of typical occurrence to break earlier
-                    if node.optionality == constraint:
-                        score_board[score][constraint].append(idx)
-                        break
-
-        # analyze and warn if more than one concept fits best, return always though the first found
-        if len(score_board) > 0:
-            alternative_best_score = max(score_board)
-            if alternative_best_score > -1:
-                for constraint in ["required", "recommended", "optional"]:
-                    # select preferentially for the harder constraint that should be met given that
-                    # we wish to validate compliance with a NeXus definition (appdef or class)
-                    if len(score_board[alternative_best_score][constraint]) > 1:
-                        logger.debug(
-                            f"Multiple best fitting with score {alternative_best_score} found "
-                            f"{[children[idx].concept_path for idx in score_board[alternative_best_score][constraint]]} "
-                            f"constrained by {constraint}; indicates possible issues with nameTyping of "
-                            f"specific NeXus classes/concepts"
-                        )
-
-        return best_match
+        variadic = [n for n in children if n is not None and n.variadic]
+        return _select_best_namefit(name, variadic, hint)
 
     def get_docstring(self, depth: int | None = None) -> dict[str, str]:
         """

--- a/src/pynxtools/nexus/schema_resolver.py
+++ b/src/pynxtools/nexus/schema_resolver.py
@@ -36,7 +36,7 @@ from pynxtools.nexus.utils import decode_if_string
 def resolve_path(
     root: NexusNode,
     path: str,
-    node_type: Literal["group", "field"] | None = None,
+    node_type: Literal["group", "field", "attribute"] | None = None,
     *,
     h5file: h5py.File | None = None,
     hint: Literal["axis", "signal"] | None = None,
@@ -259,3 +259,68 @@ class NexusSchemaResolver:
         if parent_node is None:
             return None
         return parent_node.best_child_for(attr_name, node_type="attribute")
+
+    def node_for_path(
+        self,
+        tree: NexusNode,
+        path: str,
+        node_type: Literal["group", "field", "attribute"] | None = None,
+        nx_class: str | None = None,
+        hint: Literal["axis", "signal"] | None = None,
+    ) -> NexusNode | None:
+        """Resolve *path* within *tree* without HDF5 file access.
+
+        Resolves the parent chain via :func:`resolve_path` (which fills the
+        shared node cache for every intermediate segment), then selects the last
+        segment via :meth:`~pynxtools.nexus.nexus_tree.NexusNode.best_child_for`.
+
+        Suitable for validation use cases where the application definition and
+        tree root are already known and NX_class disambiguation is provided
+        explicitly rather than read from an HDF5 file.
+
+        Parameters
+        ----------
+        tree:
+            Root of the NexusNode tree to resolve against (e.g. the ``NXentry``
+            node when validating entry-relative paths).
+        path:
+            Path without a leading slash (e.g. ``"instrument/detector"``).
+            An empty string returns *tree* itself.
+        node_type:
+            Type of the last segment: ``"group"``, ``"field"``, or
+            ``"attribute"``.
+        nx_class:
+            Optional NX class of the last segment (only meaningful for groups).
+            When given, forwarded to ``best_child_for`` for deterministic
+            variadic-group disambiguation without reading the HDF5 file.
+        hint:
+            ``"signal"`` or ``"axis"`` — forwarded to the last segment to
+            resolve the NXdata signal / axis ambiguity.
+
+        Returns
+        -------
+        NexusNode | None
+            The matching node, or ``None`` if any segment has no schema match.
+        """
+        if not path:
+            return tree
+        if path in self._node_cache:
+            return self._node_cache[path]
+
+        *parent_parts, last_seg = path.rsplit("/", 1)
+        parent_path = parent_parts[0] if parent_parts else ""
+
+        parent = (
+            resolve_path(tree, parent_path, _cache=self._node_cache)
+            if parent_path
+            else tree
+        )
+        if parent is None:
+            self._node_cache[path] = None
+            return None
+
+        node = parent.best_child_for(
+            last_seg, node_type=node_type, nx_class=nx_class, hint=hint
+        )
+        self._node_cache[path] = node
+        return node

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -27,7 +27,10 @@ from pynxtools.dataconverter.cli import validate as validate_cmd
 from pynxtools.dataconverter.helpers import get_nxdl_root_and_path
 from pynxtools.dataconverter.template import Template
 from pynxtools.dataconverter.validate_file import validate
-from pynxtools.dataconverter.validation import validate_dict_against
+from pynxtools.dataconverter.validation import (
+    validate_dict_against,
+    validate_hdf_group_against,
+)
 from pynxtools.dataconverter.writer import Writer
 
 from .test_helpers import alter_dict  # pylint: disable=unused-import
@@ -4043,3 +4046,94 @@ def test_validate_file_positive_int(
         assert observed_warnings == expected_warnings
 
     os.remove(file_path)
+
+
+# ---------------------------------------------------------------------------
+# Link validation tests
+# ---------------------------------------------------------------------------
+
+
+def _minimal_entry(h5w: h5py.File) -> None:
+    """Write a bare-minimum NXentry to *h5w* so validate_hdf_group_against has an entry."""
+    entry = h5w.create_group("entry")
+    entry.attrs["NX_class"] = "NXentry"
+
+
+def test_validate_broken_soft_link(tmp_path, caplog):
+    """A broken soft link inside the entry is reported as a BrokenLink problem."""
+    fpath = tmp_path / "broken_soft.nxs"
+    with h5py.File(fpath, "w") as h5w:
+        _minimal_entry(h5w)
+        h5w["entry/missing"] = h5py.SoftLink("/nonexistent")
+
+    with caplog.at_level(logging.WARNING):
+        with h5py.File(fpath, "r") as h5f:
+            validate_hdf_group_against(
+                "NXmpes", h5f["/entry"], str(fpath), ignore_undocumented=True
+            )
+
+    broken_msgs = [r.message for r in caplog.records if "Broken link" in r.message]
+    assert len(broken_msgs) == 1
+    assert "/entry/missing" in broken_msgs[0]
+    assert "/nonexistent" in broken_msgs[0]
+
+
+def test_validate_broken_external_link_missing_file(tmp_path, caplog):
+    """A broken external link (file missing) is reported as a BrokenLink problem."""
+    fpath = tmp_path / "main.nxs"
+    with h5py.File(fpath, "w") as h5w:
+        _minimal_entry(h5w)
+        h5w["entry/ext"] = h5py.ExternalLink("nonexistent_file.h5", "/data")
+
+    with caplog.at_level(logging.WARNING):
+        with h5py.File(fpath, "r") as h5f:
+            validate_hdf_group_against(
+                "NXmpes", h5f["/entry"], str(fpath), ignore_undocumented=True
+            )
+
+    broken_msgs = [r.message for r in caplog.records if "Broken link" in r.message]
+    assert len(broken_msgs) == 1
+    assert "/entry/ext" in broken_msgs[0]
+
+
+def test_validate_broken_external_link_missing_path(tmp_path, caplog):
+    """A broken external link (file exists, path absent) is reported as a BrokenLink problem."""
+    ext_file = tmp_path / "ext.h5"
+    with h5py.File(ext_file, "w") as h5w:
+        h5w.create_dataset("existing", data=1.0)
+
+    fpath = tmp_path / "main.nxs"
+    with h5py.File(fpath, "w") as h5w:
+        _minimal_entry(h5w)
+        h5w["entry/ext"] = h5py.ExternalLink(str(ext_file), "/nonexistent_path")
+
+    with caplog.at_level(logging.WARNING):
+        with h5py.File(fpath, "r") as h5f:
+            validate_hdf_group_against(
+                "NXmpes", h5f["/entry"], str(fpath), ignore_undocumented=True
+            )
+
+    broken_msgs = [r.message for r in caplog.records if "Broken link" in r.message]
+    assert len(broken_msgs) == 1
+    assert "/entry/ext" in broken_msgs[0]
+
+
+def test_validate_valid_external_link(tmp_path, caplog):
+    """A resolvable external link produces no BrokenLink warning."""
+    ext_file = tmp_path / "ext.h5"
+    with h5py.File(ext_file, "w") as h5w:
+        h5w.create_dataset("value", data=42.0)
+
+    fpath = tmp_path / "main.nxs"
+    with h5py.File(fpath, "w") as h5w:
+        _minimal_entry(h5w)
+        h5w["entry/ext"] = h5py.ExternalLink(str(ext_file), "/value")
+
+    with caplog.at_level(logging.WARNING):
+        with h5py.File(fpath, "r") as h5f:
+            validate_hdf_group_against(
+                "NXmpes", h5f["/entry"], str(fpath), ignore_undocumented=True
+            )
+
+    broken_msgs = [r.message for r in caplog.records if "Broken link" in r.message]
+    assert broken_msgs == []

--- a/tests/nexus/test_handler.py
+++ b/tests/nexus/test_handler.py
@@ -165,3 +165,113 @@ def test_base_visitor_does_not_raise():
 
     f = _make_in_memory_file()
     NexusFileHandler(f, is_open=True).process(_NullVisitor())
+
+
+# ---------------------------------------------------------------------------
+# Link traversal tests
+# ---------------------------------------------------------------------------
+
+
+class _LinkVisitor(_RecordingVisitor):
+    """Extends _RecordingVisitor to track broken and external links."""
+
+    def __init__(self):
+        super().__init__()
+        self.broken_links: list[tuple[str, object]] = []
+        self.external_links: list[tuple[str, h5py.ExternalLink]] = []
+
+    def on_broken_link(self, hdf_path: str, link) -> None:
+        self.broken_links.append((hdf_path, link))
+
+    def on_external_link(self, hdf_path: str, link: h5py.ExternalLink) -> None:
+        self.external_links.append((hdf_path, link))
+
+
+def test_handler_broken_soft_link(tmp_path):
+    """on_broken_link is called for a soft link whose target does not exist."""
+    fpath = tmp_path / "broken_soft.nxs"
+    with h5py.File(fpath, "w") as f:
+        f.create_group("entry")
+        f["entry/missing"] = h5py.SoftLink("/nonexistent")
+
+    visitor = _LinkVisitor()
+    NexusFileHandler(str(fpath)).process(visitor)
+
+    assert len(visitor.broken_links) == 1
+    path, link = visitor.broken_links[0]
+    assert path == "entry/missing"
+    assert isinstance(link, h5py.SoftLink)
+    assert "entry/missing" not in visitor.visited
+
+
+def test_handler_valid_soft_link(tmp_path):
+    """A resolvable soft link is visited; on_broken_link is not called."""
+    fpath = tmp_path / "valid_soft.nxs"
+    with h5py.File(fpath, "w") as f:
+        f.create_dataset("entry/real_data", data=42.0)
+        f["entry/alias"] = h5py.SoftLink("/entry/real_data")
+
+    visitor = _LinkVisitor()
+    NexusFileHandler(str(fpath)).process(visitor)
+
+    assert visitor.broken_links == []
+    assert "entry/real_data" in visitor.visited
+
+
+def test_handler_broken_external_link_missing_file(tmp_path):
+    """on_broken_link fires when the external file does not exist."""
+    fpath = tmp_path / "main.nxs"
+    with h5py.File(fpath, "w") as f:
+        f["entry/ext"] = h5py.ExternalLink("nonexistent.h5", "/data")
+
+    visitor = _LinkVisitor()
+    NexusFileHandler(str(fpath)).process(visitor)
+
+    assert len(visitor.broken_links) == 1
+    path, link = visitor.broken_links[0]
+    assert path == "entry/ext"
+    assert isinstance(link, h5py.ExternalLink)
+    assert len(visitor.external_links) == 1
+
+
+def test_handler_broken_external_link_missing_path(tmp_path):
+    """on_broken_link fires when the external file exists but the path is absent."""
+    ext_file = tmp_path / "ext.h5"
+    with h5py.File(ext_file, "w") as f:
+        f.create_dataset("existing", data=1.0)
+
+    main_file = tmp_path / "main.nxs"
+    with h5py.File(main_file, "w") as f:
+        f["entry/ext"] = h5py.ExternalLink(str(ext_file), "/nonexistent")
+
+    visitor = _LinkVisitor()
+    NexusFileHandler(str(main_file)).process(visitor)
+
+    assert len(visitor.broken_links) == 1
+    path, link = visitor.broken_links[0]
+    assert path == "entry/ext"
+    assert isinstance(link, h5py.ExternalLink)
+
+
+def test_handler_valid_external_link(tmp_path):
+    """A resolvable external link is traversed; on_external_link fires before traversal."""
+    ext_file = tmp_path / "ext.h5"
+    with h5py.File(ext_file, "w") as f:
+        grp = f.create_group("sensor")
+        grp.create_dataset("value", data=3.14)
+
+    main_file = tmp_path / "main.nxs"
+    with h5py.File(main_file, "w") as f:
+        f["entry/ext"] = h5py.ExternalLink(str(ext_file), "/sensor")
+
+    visitor = _LinkVisitor()
+    NexusFileHandler(str(main_file)).process(visitor)
+
+    assert visitor.broken_links == []
+    assert len(visitor.external_links) == 1
+    ext_path, ext_link = visitor.external_links[0]
+    assert ext_path == "entry/ext"
+    assert isinstance(ext_link, h5py.ExternalLink)
+    # The external subtree is visited under the main-file path
+    assert "entry/ext" in visitor.visited
+    assert "entry/ext/value" in visitor.visited


### PR DESCRIPTION
## Summary

This PR implements the NeXus visitor architecture by migrating the HDF5 file validator to the `NexusVisitor` / `NexusFileHandler` pattern established by the annotator, and by consolidating the schema-resolution infrastructure that both tools share.

### What changed

#### `dataconverter/validation.py` — `ValidationVisitor`

The free function `validate_hdf_group_against` (with its nested closures and `LRUCache`) is replaced by `ValidationVisitor`, a concrete `NexusVisitor` implementation driven by `NexusFileHandler`.

- File traversal, link resolution, and soft/external/broken-link detection are fully delegated to the handler.  `ValidationVisitor` only contains (limited) schema-resolution and problem-collection logic.
- `_find_node_for` now delegates to `NexusSchemaResolver.node_for_path` (see below), removing the bespoke `LRUCache`-backed closure. 
- `_variadic_node_exists_for` now calls `resolve_path` directly — deliberately bypassing the resolver cache to avoid polluting the shared HDF5-path cache with NXDL concept paths.
- The `best_namefit_of` local function inside `validate_dict_against` is replaced by `_select_best_namefit` (see below).
- `validate_hdf_group_against` is retained as a one-line backward-compatible wrapper.

#### `nexus/handler.py` — two optional hooks on `NexusVisitor`

Two optional hooks with default no-op implementations are added to the base class:

- `on_broken_link(hdf_path, link)` — called when a soft or external link cannot be resolved. `ValidationVisitor` overrides this to emit a `BrokenLink` problem.
- `on_external_link(hdf_path, link)` — called when an external link is first encountered, before the handler opens the external file.

`NexusFileHandler` now handles soft links, hard links (with cycle guard), and external links. Broken links dispatch `on_broken_link` and are otherwiseskipped. Cycle detection is extended to tolerate ancestor paths that do not
exist in the current root (e.g. when traversing an external file).

#### `nexus/nexus_tree.py` — `_select_best_namefit`

The scoreboard logic that was duplicated between `NexusNode.best_child_for` and `validate_dict_against.best_namefit_of` is extracted into a single module-level function `_select_best_namefit(name, nodes, hint)`.

- `best_child_for` is refactored to a two-pass approach: non-variadic exact match first, then `_select_best_namefit` on the variadic candidates.
- `required_fields_and_attrs_names` no longer adds `/@units` to the required entity list for fields with `unit="NX_UNITLESS"`

#### `nexus/schema_resolver.py` — `NexusSchemaResolver.node_for_path`

A new method `node_for_path(tree, path, node_type, nx_class, hint)` resolves a path within a known `NexusNode` tree without HDF5 file access.  This covers the `ValidationVisitor` use case (appdef and tree root are already known; NX_class
disambiguation is supplied explicitly) without duplicating the cache or the `best_child_for` call chain.

`resolve_path` gains support for `node_type="attribute"` in its signature so that callers can request attribute resolution at the last segment.

### What did not change

- The `validate_dict_against` entry point and its keyword arguments are unchanged.
- `validate_hdf_group_against` signature is unchanged (backward-compatible wrapper).
- All `ValidationProblem` codes and their log messages are unchanged.
- The `Annotator` and `NomadVisitor` implementations are not modified.

## Tests

- `tests/dataconverter/test_validation.py` — extended with link-traversal cases (soft links, external links, broken links within an entry).
- `tests/nexus/test_handler.py` — new file; covers `NexusFileHandler` linktraversal behaviour via a lightweight spy visitor, including cycle detection and broken external links.
