### PR TITLE
Fix duplicated log output caused by root-logger propagation

### DIFF
--- a/src/pynxtools/__init__.py
+++ b/src/pynxtools/__init__.py
@@ -40,6 +40,7 @@ formatter = CustomFormatter("%(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
+logger.propagate = False
 
 
 def _build_version(tag: str, distance: int, node: str, dirty: bool) -> str:


### PR DESCRIPTION
Fixes #811 

Set `logger.propagate = False` on the `"pynxtools"` logger, so its records stay local to its own handler regardless of what else (re)configures the root logger.

This only addresses the pynxtools side. The underlying NOMAD-side issue (`nomad.utils.structlogging` mutating the global root logger as an import-time side effect (`configure_logging()` called at module scope)) is still present and can affect any other tool that imports `nomad-lab`. We could maybe discuss this with Area D at some point.