### PR TITLE
remove deprecated dataconverter from docs

### DIFF
--- a/docs/how-tos/nexus/write-an-application-definition.md
+++ b/docs/how-tos/nexus/write-an-application-definition.md
@@ -209,15 +209,13 @@ You can learn more in the [`nyaml` documentation](https://fairmat-nfdi.github.io
 Place the file in `src/pynxtools/definitions/contributed_definitions/` and run:
 
 ```bash
-dataconverter generate-template --nxdl NXdouble_slit
+pynx convert generate-template NXdouble_slit
 ```
 
 This confirms `pynxtools` resolves the definition and lists all expected paths.
 
 !!! note
-    The `dataconverter generate-template` method does not actually validate the NeXus definition
-    by itself. Rather, it creates a `pynxtools` template from a given application definition. 
-    For this to work, the application definition has to be valid.
+    The `pynx convert generate-template` method does not actually validate the NeXus definition by itself. Rather, it creates a `pynxtools` template from a given application definition. For this to work, the application definition has to be valid.
 
     Note that there exists a [validation workflow](https://github.com/FAIRmat-NFDI/nexus_definitions/blob/fairmat/.github/workflows/validate.yaml) that is run in the GitHub CI/CD of the definitions repository. For this to run on your NXDL file, you need to add your application definition there (see below).
 

--- a/docs/learn/pynxtools/dataconverter-append-mode.md
+++ b/docs/learn/pynxtools/dataconverter-append-mode.md
@@ -11,9 +11,9 @@ passing the `--append` flag during command line invocation (see [Tutorial -> Con
 
 We take this tutorial and its `NXxps` case study as an example. It composes the HDF5 file with content from two input files: the `EX439_S718_Au.sle` with proprietary formatting and the `eln_data_sle.yaml`, a NOMAD-specific metadata exchange file. Instead of running the tutorial with passing both input in one go, one could first add process only the proprietary file (without using `--append`) and thereafter process the YAML file (with using `--append`). The minimal command line call reads as follows.
 
-```
-dataconverter EX439_S718_Au.sle --reader xps --nxdl NXxps --output Au_25_mbar_O2_no_align.nxs
-dataconverter eln_data_sle.yaml --reader xps --nxdl NXxps --append --output Au_25_mbar_O2_no_align.nxs
+```bash
+pynx convert EX439_S718_Au.sle --reader xps --nxdl NXxps --output Au_25_mbar_O2_no_align.nxs
+pynx convert eln_data_sle.yaml --reader xps --nxdl NXxps --append --output Au_25_mbar_O2_no_align.nxs
 ```
 
 When processing both the `*.sle` and `*.yaml` file in one call, adding `--append` has no effect, i.e.,

--- a/docs/tutorial/bring-your-own-data.md
+++ b/docs/tutorial/bring-your-own-data.md
@@ -381,7 +381,8 @@ and installed `pynxtools` plugins:
 Test whether the application definition is known:
 
 ```bash
-dataconverter generate-template --nxdl NXmpes
+pynx convert generate-template NXmpes
+
 ```
 
 ### No application definition? Write a minimal one.
@@ -421,7 +422,8 @@ Add it to point `pynxtools` in the `contributed_definitions` folder.
 ### Mapping checklist
 
 ```bash
-dataconverter generate-template --nxdl <YOUR_NXDL> > template.txt
+pynx convert generate-template <YOUR_NXDL> > template.txt
+
 ```
 
 Work through the output line by line.  For each path, fill in the
@@ -466,7 +468,7 @@ NeXus requires units for every numeric field.  Options:
 ## Step 6 — Convert, validate, iterate (~20 min)
 
 ```bash
-dataconverter \
+pynx convert \
     your_file.ext \
     eln_data.yaml \
     config_file.json \
@@ -562,7 +564,7 @@ def post_process(self) -> None:
 
 ## Checklist before you leave
 
-- [ ] `dataconverter` runs without errors on your own data
+- [ ] `pynx convert` runs without errors on your own data
 - [ ] All required fields in the application definition are present in `output.nxs`
 - [ ] Units are set for every numeric field
 - [ ] `reader.py` and `config_file.json` are committed to your repository

--- a/docs/tutorial/build-a-reader.md
+++ b/docs/tutorial/build-a-reader.md
@@ -106,7 +106,7 @@ uv pip install -e ".[dev]"
 ### Verify the setup
 
 ```bash
-dataconverter --help
+pynx convert --help
 ```
 
 If you see the help text, you're ready.
@@ -203,7 +203,7 @@ You will see groups, fields, and attributes.  Each element has an **optionality*
 Now generate the **template** — the full list of paths the appdef expects:
 
 ```bash
-dataconverter generate-template --nxdl NXsimple
+pynx convert generate-template NXsimple
 ```
 
 The output shows every path and its requirement level.
@@ -515,7 +515,7 @@ It is a JSON file where:
 
 ### Step 1 — compare the appdef to your data
 
-Run `dataconverter generate-template --nxdl NXsimple` again.
+Run `pynx convert generate-template NXsimple` again.
 For each required or recommended path, decide:
 
 - Is the value in `self.hdf5_data`? → use `"@attrs:<hdf5-path>"`
@@ -594,7 +594,7 @@ Create `tests/data/workshop-example/my_config.json` and fill it in.
 ## 7 — Run the converter (~15 min)
 
 ```bash
-dataconverter \
+pynx convert \
     tests/data/workshop-example/mock_data.h5 \
     tests/data/workshop-example/eln_data.yaml \
     tests/data/workshop-example/my_config.json \
@@ -632,7 +632,7 @@ output file is provided in `tests/data/workshop-example/`.
 Generate it from your working reader:
 
 ```bash
-dataconverter \
+pynx convert \
     tests/data/workshop-example/mock_data.h5 \
     tests/data/workshop-example/eln_data.yaml \
     tests/data/workshop-example/config_file.json \
@@ -741,7 +741,7 @@ plt.show()
 | Exercise 2b | `handle_eln_file` | `parse_yml` for ELN → template paths |
 | Exercises 3–5 | Three callback methods | The `@prefix:path` dispatch pattern |
 | Exercise 6 | `config_file.json` | Semantic source↔NeXus mapping |
-| Run | `dataconverter` | Validation is automatic |
+| Run | `pynx convert` | Validation is automatic |
 | Tests | `pytest` | Reproducibility testing |
 | Section 7 | Uploaded to NOMAD | NeXus files are parsed automatically; explore via DATA tab and NORTH |
 

--- a/docs/tutorial/writing-an-application-definition.md
+++ b/docs/tutorial/writing-an-application-definition.md
@@ -86,7 +86,7 @@ Every application definition is an XML file following the NXDL schema. Create `N
 If you have `pynxtools` installed (see [Installation Guide](./installation.md)), add the NXDL XML file under `src/pynxtools/definitions/contributed_definitions` and validate that pynxtools can read it:
 
 ```bash
-dataconverter generate-template --nxdl NXdouble_slit
+pynx convert generate-template NXdouble_slit
 ```
 
 You should see a JSON template listing paths like `/ENTRY[entry]/title` and `/ENTRY[entry]/start_time`.
@@ -384,7 +384,7 @@ nyaml2nxdl NXdouble_slit.yaml --output-file NXdouble_slit.nxdl.xml
 Run `generate-template` one final time and check that all required paths are listed:
 
 ```bash
-dataconverter generate-template --nxdl NXdouble_slit
+pynx convert generate-template NXdouble_slit
 ```
 
 Write a minimal HDF5 test file filling all required fields, then validate:
@@ -504,7 +504,7 @@ cp NXdouble_slit.nxdl.xml  src/pynxtools/definitions/contributed_definitions/
 Verify that pynxtools picks them up:
 
 ```bash
-dataconverter generate-template --nxdl NXdouble_slit
+pynx convert generate-template NXdouble_slit
 ```
 
 This change lives only in your local checkout. It is useful for iterating quickly before submitting upstream.


### PR DESCRIPTION
- Removes all mentions of the deprecated `dataconverter` command from the docs
- Remove `--nxdl` flag from `pynx convert generate-template <NXDL>` in the docs
- Spurious whitespace changes