### PR TITLE
fix: pynx CLI requires nomad-lab even for non-NOMAD commands

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          uv pip install ".[docs]"
+          uv pip install ".[docs,nomad]"
 
       - name: Build and Deploy
         run: |

--- a/src/pynxtools/cli.py
+++ b/src/pynxtools/cli.py
@@ -39,12 +39,39 @@ from pynxtools.annotator.cli import read
 from pynxtools.dataconverter.cli import convert, validate
 from pynxtools.eln_mapper.cli import generate_eln
 from pynxtools.nexus.cli import inspect_appdef
-from pynxtools.nomad.cli import nomad
+
+
+class _LazyNomadGroup(click.Group):
+    """``pynx nomad`` sub-group, loaded on first use.
+
+    ``pynxtools.nomad`` requires the ``nomad`` extra (``nomad-lab``). Importing
+    it eagerly here would make every ``pynx`` invocation, including commands
+    unrelated to NOMAD, fail for users who only installed the base package.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(name="nomad", help="NOMAD integration tools.")
+
+    def _resolve(self) -> click.Group:
+        try:
+            from pynxtools.nomad.cli import nomad
+        except ImportError as exc:
+            raise click.ClickException(
+                "'pynx nomad' requires the 'nomad' extra. "
+                "Install it with: pip install 'pynxtools[nomad]'"
+            ) from exc
+        return nomad
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        return self._resolve().list_commands(ctx)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        return self._resolve().get_command(ctx, cmd_name)
 
 
 @click.group()
 def pynx():
-    """pynxtools – NeXus file tools.
+    """pynxtools NeXus file tools.
 
     Use ``pynx COMMAND --help`` for details on each sub-command.
     """
@@ -55,4 +82,4 @@ pynx.add_command(convert, name="convert")
 pynx.add_command(validate, name="validate")
 pynx.add_command(generate_eln, name="generate-eln")
 pynx.add_command(inspect_appdef, name="inspect-appdef")
-pynx.add_command(nomad, name="nomad")
+pynx.add_command(_LazyNomadGroup(), name="nomad")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@
 """CLI tests for the top-level ``pynx`` dispatcher."""
 
 import builtins
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -32,7 +33,13 @@ def runner():
 
 @pytest.fixture()
 def without_nomad_lab(monkeypatch):
-    """Simulate an environment where the ``nomad`` extra is not installed."""
+    """Simulate an environment where the ``nomad`` extra is not installed.
+
+    Blocking ``import nomad`` alone is not enough: earlier-collected test
+    modules (e.g. tests/nomad/*) already import ``pynxtools.nomad*``, so
+    without evicting those from ``sys.modules`` the cache hit would make the
+    block a no-op and this fixture would silently do nothing.
+    """
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
@@ -41,6 +48,15 @@ def without_nomad_lab(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    for name in list(sys.modules):
+        if (
+            name == "nomad"
+            or name.startswith("nomad.")
+            or name == "pynxtools.nomad"
+            or name.startswith("pynxtools.nomad.")
+        ):
+            monkeypatch.delitem(sys.modules, name, raising=False)
 
 
 class TestPynxGroup:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,105 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""CLI tests for the top-level ``pynx`` dispatcher."""
+
+import builtins
+
+import pytest
+from click.testing import CliRunner
+
+from pynxtools.cli import pynx
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def without_nomad_lab(monkeypatch):
+    """Simulate an environment where the ``nomad`` extra is not installed."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "nomad" or name.startswith("nomad."):
+            raise ImportError("No module named 'nomad'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+class TestPynxGroup:
+    """Baseline tests for the top-level dispatcher, independent of
+    whether the ``nomad`` extra is installed."""
+
+    def test_lists_all_subcommands(self, runner):
+        result = runner.invoke(pynx, ["--help"])
+        assert result.exit_code == 0
+        for name in (
+            "read",
+            "convert",
+            "validate",
+            "generate-eln",
+            "inspect-appdef",
+            "nomad",
+        ):
+            assert name in result.output
+
+    def test_unknown_command_fails(self, runner):
+        result = runner.invoke(pynx, ["does-not-exist"])
+        assert result.exit_code != 0
+
+
+class TestNomadExtraOptional:
+    """Regression test: importing pynxtools.nomad requires nomad-lab, but
+    that must not break unrelated ``pynx`` commands."""
+
+    def test_help_lists_nomad_without_importing_it(self, runner, without_nomad_lab):
+        result = runner.invoke(pynx, ["--help"])
+        assert result.exit_code == 0
+        assert "nomad" in result.output
+
+    def test_non_nomad_command_still_works(self, runner, without_nomad_lab):
+        result = runner.invoke(pynx, ["validate", "--help"])
+        assert result.exit_code == 0
+
+    def test_nomad_command_fails_with_actionable_error(self, runner, without_nomad_lab):
+        result = runner.invoke(pynx, ["nomad", "--help"])
+        assert result.exit_code != 0
+        assert "nomad" in result.output
+        assert "pip install" in result.output
+
+
+class TestNomadExtraPresent:
+    """With nomad-lab actually installed, the lazy group must behave like a
+    normal eagerly-registered click group (this dev environment has the
+    ``nomad`` extra installed, so these run against the real import)."""
+
+    def test_nomad_help_lists_subcommands(self, runner):
+        result = runner.invoke(pynx, ["nomad", "--help"])
+        assert result.exit_code == 0
+        assert "generate-metainfo" in result.output
+
+    def test_nomad_generate_metainfo_help(self, runner):
+        result = runner.invoke(pynx, ["nomad", "generate-metainfo", "--help"])
+        assert result.exit_code == 0
+        assert "--nxdl" in result.output
+
+    def test_nomad_unknown_subcommand_fails(self, runner):
+        result = runner.invoke(pynx, ["nomad", "does-not-exist"])
+        assert result.exit_code != 0


### PR DESCRIPTION
`pynx` eagerly imported `pynxtools.nomad.cli` at module load time, which unconditionally imports `nomad-lab` and raises `ImportError` if the optional `'nomad'` extra isn't installed. This broke every `pynx` command, not just `pynx nomad`.

Fix is to make the `nomad` sub-group lazily import `pynxtools.nomad.cli` only when `pynx nomad ...` is actually invoked, and rasise a clear `ClickException` pointing at `'pip install pynxtools[nomad]'` when it's missing.

Also adds a bunch of tests for the main CLI tool itselt, including a monkeypatch test to see what happens if `nomad-lab` is not installed.

Fixes #822