### PR TITLE
fix: preserve link/VDS template entries through validate_dict_against

### DIFF
--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -1037,25 +1037,17 @@ def validate_dict_against(
 
     def handle_nxdata(node: NexusGroup, keys: Mapping[str, Any], prev_path: str):
         def check_nxdata():
-            # `resolved_keys` (a `_follow_link`-resolved copy) is used to read
-            # realized values for the shape/length checks below. The *original*,
-            # unresolved `keys` is what gets passed into `handle_field` so that
-            # function can still see (and preserve) a {"link": ...} entry itself -
-            # handing it an already-resolved value here would make `handle_field`
-            # think the field was never a link, and it would write the realized
-            # value back into the global template, destroying the link/VDS shape.
+            # `resolved_keys` is for realized values (shape/length checks below);
+            # `handle_field` gets the original `keys` so it still sees (and
+            # preserves) a {"link": ...} entry instead of overwriting it.
             data = (
                 resolved_keys.get(f"DATA[{signal}]")
                 if f"DATA[{signal}]" in resolved_keys
                 else resolved_keys.get(signal)
             )
             if isinstance(data, np.ndarray):
-                # `_follow_link` resolves to the full link target and ignores any
-                # "shape" slice request (VDS assembly is the writer's job) - so for
-                # a sliced VDS field, `data` here is still the *unsliced* target.
-                # Apply the original entry's "shape" (if any) before using `data`
-                # for the axis-length comparison below, or a correctly sliced VDS
-                # signal spuriously fails NXdataAxisMismatch against its axis.
+                # _follow_link ignores "shape", so `data` is still unsliced here -
+                # apply it before the axis-length comparison below.
                 original_value = (
                     keys.get(f"DATA[{signal}]")
                     if f"DATA[{signal}]" in keys
@@ -1146,12 +1138,9 @@ def validate_dict_against(
         indices = list(map(lambda x: f"{x}_indices", axes))
         errors = list(map(lambda x: f"{x}_errors", [signal, *aux_signals, *axes]))
 
-        # Handle all remaining keys which are not part of NXdata. Field keys may be
-        # written with or without their variadic wrapper (e.g. "Psi_50deg" or
-        # "DATA[Psi_50deg]", "wavelength" or "AXISNAME[wavelength]") - exclude both
-        # forms, or an already-handled link field leaks through here and gets
-        # resolved a second time below, corrupting it (see check_nxdata, which
-        # already handles the signal/axes fields themselves via handle_field).
+        # Handle all remaining keys which are not part of NXdata. Field keys may
+        # appear bare ("Psi_50deg") or wrapped ("DATA[Psi_50deg]") - exclude both
+        # forms, or an already-handled field leaks back in and gets corrupted.
         def _wrapped(names: list, wrapper: str) -> set:
             result = set(names)
             result.update(f"{wrapper}[{name}]" for name in names)
@@ -1165,12 +1154,8 @@ def validate_dict_against(
         )
         remaining_keys = {x: keys[x] for x in keys if x not in handled_names}
         remaining_keys = _follow_link(remaining_keys, prev_path)
-        # `search_add_child_for_multiple` in check_nxdata() adds concrete
-        # variant-named children (e.g. "Psi_50deg", "DATA[Psi_50deg]") to `node`
-        # alongside the generic "DATA"/"AXISNAME" wildcard children - both bare and
-        # bracketed forms must be ignored here too, or recurse_tree visits that
-        # concrete child a second time and re-triggers handle_field on an
-        # already-resolved value, corrupting it the same way `remaining_keys` did.
+        # check_nxdata() adds concrete variant-named children (bare and wrapped)
+        # to `node` too - ignore both forms so recurse_tree doesn't revisit them.
         recurse_tree(
             node,
             remaining_keys,
@@ -1178,12 +1163,9 @@ def validate_dict_against(
             ignore_names=[
                 "DATA",
                 "AXISNAME",
-                # Deliberately NOT "AXISNAME_indices": unlike DATA/AXISNAME, an
-                # AXISNAME_indices instance (e.g. "@axis_a_indices") can be required
-                # independent of whether `axes` is non-empty here, and is not itself
-                # a link/VDS field - skip only the specific instances already
-                # covered by check_nxdata via `handled_names`, not the whole concept,
-                # or its required-attribute check silently never runs.
+                # Not "AXISNAME_indices": an instance like "@axis_a_indices" can be
+                # required independent of `axes` here, so only the specific
+                # instances in `handled_names` are skipped, not the whole concept.
                 "FIELDNAME_errors",
                 "signal",
                 "auxiliary_signals",
@@ -1268,13 +1250,9 @@ def validate_dict_against(
                 continue
 
             if node.nx_class == "NXdata":
-                # handle_nxdata() already walks this group's fields (signal, axes,
-                # auxiliary signals, everything else). Falling through to the
-                # generic branch below would process it a second time with
-                # already-`_follow_link`-resolved values, silently overwriting any
-                # {"link": ...} field entries (including sliced VDS "shape"
-                # requests) with their fully realized, unsliced form - this used to
-                # be `if`/`if`/`else`, which ran both branches for NXdata groups.
+                # Was `if`/`if`/`else`, so this ran alongside the generic branch
+                # below too - reprocessing fields with resolved values and
+                # corrupting any {"link": ...}/VDS "shape" entries.
                 handle_nxdata(node, keys[variant], prev_path=variant_path)
             elif node.nx_class == "NXcollection":
                 return
@@ -1445,11 +1423,8 @@ def validate_dict_against(
                 variant_value = resolved_link[variant]
 
             if isinstance(variant_value, Mapping) and "link" in variant_value:
-                # Multi-source VDS links (a list under "link") are deliberately left
-                # unresolved by _follow_link - VDS assembly happens in the writer, not
-                # here. There's no realized value to type/shape-check against the
-                # schema, so accept it as-is rather than treating the still-dict value
-                # as an invalid nested structure.
+                # Multi-source VDS link (list) - _follow_link deliberately leaves it
+                # unresolved, so accept it rather than flag it as an invalid struct.
                 continue
 
             if (
@@ -1542,12 +1517,8 @@ def validate_dict_against(
                     )
                 continue
 
-            # Check general validity. For a link-backed field this validates the
-            # *resolved* value's type/shape against the schema, but the mapping must
-            # keep the original {"link": ...} entry - overwriting it here would
-            # destroy the link (and any VDS "shape" slice) before the Writer ever
-            # sees it, silently turning a virtual/linked dataset into a fully
-            # realized, unsliced copy.
+            # Check general validity - for a link, `mapping` must keep the original
+            # {"link": ...} entry, not the resolved value used for this check.
             checked_value = is_valid_data_field(
                 variant_value,
                 node.dtype,

--- a/src/pynxtools/dataconverter/validation.py
+++ b/src/pynxtools/dataconverter/validation.py
@@ -1037,11 +1037,32 @@ def validate_dict_against(
 
     def handle_nxdata(node: NexusGroup, keys: Mapping[str, Any], prev_path: str):
         def check_nxdata():
+            # `resolved_keys` (a `_follow_link`-resolved copy) is used to read
+            # realized values for the shape/length checks below. The *original*,
+            # unresolved `keys` is what gets passed into `handle_field` so that
+            # function can still see (and preserve) a {"link": ...} entry itself -
+            # handing it an already-resolved value here would make `handle_field`
+            # think the field was never a link, and it would write the realized
+            # value back into the global template, destroying the link/VDS shape.
             data = (
-                keys.get(f"DATA[{signal}]")
-                if f"DATA[{signal}]" in keys
-                else keys.get(signal)
+                resolved_keys.get(f"DATA[{signal}]")
+                if f"DATA[{signal}]" in resolved_keys
+                else resolved_keys.get(signal)
             )
+            if isinstance(data, np.ndarray):
+                # `_follow_link` resolves to the full link target and ignores any
+                # "shape" slice request (VDS assembly is the writer's job) - so for
+                # a sliced VDS field, `data` here is still the *unsliced* target.
+                # Apply the original entry's "shape" (if any) before using `data`
+                # for the axis-length comparison below, or a correctly sliced VDS
+                # signal spuriously fails NXdataAxisMismatch against its axis.
+                original_value = (
+                    keys.get(f"DATA[{signal}]")
+                    if f"DATA[{signal}]" in keys
+                    else keys.get(signal)
+                )
+                if isinstance(original_value, Mapping) and "shape" in original_value:
+                    data = data[original_value["shape"]]
             if data is None:
                 collector.collect_and_log(
                     f"{prev_path}/{signal}",
@@ -1069,18 +1090,18 @@ def validate_dict_against(
             for attr in ("signal", "auxiliary_signals", "axes"):
                 handle_attribute(
                     node.search_add_child_for(attr),
-                    keys,
+                    resolved_keys,
                     prev_path=prev_path,
                 )
 
             for i, axis in enumerate(axes):
                 if axis == ".":
                     continue
-                index = keys.get(f"{axis}_indices", i)
+                index = resolved_keys.get(f"{axis}_indices", i)
 
-                if f"AXISNAME[{axis}]" in keys:
+                if f"AXISNAME[{axis}]" in resolved_keys:
                     axis = f"AXISNAME[{axis}]"
-                axis_data = _follow_link(keys.get(axis), prev_path)
+                axis_data = _follow_link(resolved_keys.get(axis), prev_path)
                 if axis_data is None:
                     collector.collect_and_log(
                         f"{prev_path}/{axis}",
@@ -1112,26 +1133,44 @@ def validate_dict_against(
                         index,
                     )
 
-        keys = _follow_link(keys, prev_path)
-        signal = keys.get("@signal")
-        aux_signals = keys.get("@auxiliary_signals", [])
-        axes = keys.get("@axes", [])
+        resolved_keys = _follow_link(keys, prev_path)
+        signal = resolved_keys.get("@signal")
+        aux_signals = resolved_keys.get("@auxiliary_signals", [])
+        axes = resolved_keys.get("@axes", [])
         if isinstance(axes, str):
             axes = [axes]
 
         if signal is not None:
             check_nxdata()
 
-        indices = map(lambda x: f"{x}_indices", axes)
-        errors = map(lambda x: f"{x}_errors", [signal, *aux_signals, *axes])
+        indices = list(map(lambda x: f"{x}_indices", axes))
+        errors = list(map(lambda x: f"{x}_errors", [signal, *aux_signals, *axes]))
 
-        # Handle all remaining keys which are not part of NXdata
-        remaining_keys = {
-            x: keys[x]
-            for x in keys
-            if x not in [signal, *axes, *indices, *errors, *aux_signals]
-        }
+        # Handle all remaining keys which are not part of NXdata. Field keys may be
+        # written with or without their variadic wrapper (e.g. "Psi_50deg" or
+        # "DATA[Psi_50deg]", "wavelength" or "AXISNAME[wavelength]") - exclude both
+        # forms, or an already-handled link field leaks through here and gets
+        # resolved a second time below, corrupting it (see check_nxdata, which
+        # already handles the signal/axes fields themselves via handle_field).
+        def _wrapped(names: list, wrapper: str) -> set:
+            result = set(names)
+            result.update(f"{wrapper}[{name}]" for name in names)
+            return result
+
+        handled_names = (
+            _wrapped([signal, *aux_signals], "DATA")
+            | _wrapped(axes, "AXISNAME")
+            | _wrapped(indices, "AXISNAME_indices")
+            | _wrapped(errors, "FIELDNAME_errors")
+        )
+        remaining_keys = {x: keys[x] for x in keys if x not in handled_names}
         remaining_keys = _follow_link(remaining_keys, prev_path)
+        # `search_add_child_for_multiple` in check_nxdata() adds concrete
+        # variant-named children (e.g. "Psi_50deg", "DATA[Psi_50deg]") to `node`
+        # alongside the generic "DATA"/"AXISNAME" wildcard children - both bare and
+        # bracketed forms must be ignored here too, or recurse_tree visits that
+        # concrete child a second time and re-triggers handle_field on an
+        # already-resolved value, corrupting it the same way `remaining_keys` did.
         recurse_tree(
             node,
             remaining_keys,
@@ -1139,16 +1178,17 @@ def validate_dict_against(
             ignore_names=[
                 "DATA",
                 "AXISNAME",
-                "AXISNAME_indices",
+                # Deliberately NOT "AXISNAME_indices": unlike DATA/AXISNAME, an
+                # AXISNAME_indices instance (e.g. "@axis_a_indices") can be required
+                # independent of whether `axes` is non-empty here, and is not itself
+                # a link/VDS field - skip only the specific instances already
+                # covered by check_nxdata via `handled_names`, not the whole concept,
+                # or its required-attribute check silently never runs.
                 "FIELDNAME_errors",
                 "signal",
                 "auxiliary_signals",
                 "axes",
-                signal,
-                *axes,
-                *indices,
-                *errors,
-                *aux_signals,
+                *handled_names,
             ],
         )
 
@@ -1228,8 +1268,15 @@ def validate_dict_against(
                 continue
 
             if node.nx_class == "NXdata":
+                # handle_nxdata() already walks this group's fields (signal, axes,
+                # auxiliary signals, everything else). Falling through to the
+                # generic branch below would process it a second time with
+                # already-`_follow_link`-resolved values, silently overwriting any
+                # {"link": ...} field entries (including sliced VDS "shape"
+                # requests) with their fully realized, unsliced form - this used to
+                # be `if`/`if`/`else`, which ran both branches for NXdata groups.
                 handle_nxdata(node, keys[variant], prev_path=variant_path)
-            if node.nx_class == "NXcollection":
+            elif node.nx_class == "NXcollection":
                 return
             else:
                 variant_keys = _follow_link(keys[variant], variant_path)
@@ -1385,7 +1432,10 @@ def validate_dict_against(
             variant_path = remove_from_not_visited(f"{prev_path}/{variant}")
 
             variant_value = keys[variant]
-            if isinstance(variant_value, Mapping) and "link" in variant_value:
+            is_link_value = (
+                isinstance(variant_value, Mapping) and "link" in variant_value
+            )
+            if is_link_value:
                 resolved_link = _follow_link({variant: variant_value}, prev_path)
                 if (
                     not isinstance(resolved_link, Mapping)
@@ -1393,6 +1443,14 @@ def validate_dict_against(
                 ):
                     continue
                 variant_value = resolved_link[variant]
+
+            if isinstance(variant_value, Mapping) and "link" in variant_value:
+                # Multi-source VDS links (a list under "link") are deliberately left
+                # unresolved by _follow_link - VDS assembly happens in the writer, not
+                # here. There's no realized value to type/shape-check against the
+                # schema, so accept it as-is rather than treating the still-dict value
+                # as an invalid nested structure.
+                continue
 
             if (
                 isinstance(variant_value, Mapping)
@@ -1484,14 +1542,21 @@ def validate_dict_against(
                     )
                 continue
 
-            # Check general validity
-            mapping[variant_path] = is_valid_data_field(
+            # Check general validity. For a link-backed field this validates the
+            # *resolved* value's type/shape against the schema, but the mapping must
+            # keep the original {"link": ...} entry - overwriting it here would
+            # destroy the link (and any VDS "shape" slice) before the Writer ever
+            # sees it, silently turning a virtual/linked dataset into a fully
+            # realized, unsliced copy.
+            checked_value = is_valid_data_field(
                 variant_value,
                 node.dtype,
                 variant_path,
             )
+            if not is_link_value:
+                mapping[variant_path] = checked_value
             is_valid_enum(
-                mapping[variant_path],
+                checked_value,
                 node.items,
                 node.open_enum,
                 variant_path,

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -2236,15 +2236,51 @@ def format_error_message(msg: str) -> str:
             ],
             id="missing-required-variadic-axisname-indices-attribute",
         ),
+        pytest.param(
+            alter_dict(
+                TEMPLATE,
+                "/ENTRY[my_entry]/NXODD_name[nxodd_name]/DATA[data]",
+                {
+                    "link": "/my_entry/nxodd_name/posint_value",
+                    "shape": (slice(0, 2),),
+                },
+            ),
+            "",
+            id="nxdata-signal-link-with-shape-not-mutated",
+        ),
+        pytest.param(
+            alter_dict(
+                TEMPLATE,
+                "/ENTRY[my_entry]/NXODD_name[nxodd_name]/DATA[data]",
+                {"link": ["file1.h5:/data", "file2.h5:/data"]},
+            ),
+            "",
+            id="list-form-vds-link-not-misclassified",
+        ),
     ],
 )
 def test_validate_data_dict(data_dict, error_messages, caplog, request):
     """Unit test for the data validation routine on the template."""
 
     if not error_messages:
+        link_path = "/ENTRY[my_entry]/NXODD_name[nxodd_name]/DATA[data]"
+        original_value = (
+            data_dict["required"].get(link_path)
+            if request.node.callspec.id
+            in (
+                "nxdata-signal-link-with-shape-not-mutated",
+                "list-form-vds-link-not-misclassified",
+            )
+            else None
+        )
         with caplog.at_level(logging.WARNING):
             assert validate_dict_against("NXtest", data_dict)
         assert caplog.text == ""
+        if original_value is not None:
+            # validate_dict_against() resolves a {"link": ...} entry to check its
+            # type/shape against the schema, but must leave the original link (and
+            # any VDS "shape" slice) in the template - the Writer needs it intact.
+            assert data_dict["required"][link_path] == original_value
     else:
         if request.node.callspec.id in (
             "field-with-illegal-unit",
@@ -3672,6 +3708,18 @@ def test_validate_data_dict(data_dict, error_messages, caplog, request):
             ],
             id="missing-required-variadic-axisname-indices-attribute",
         ),
+        pytest.param(
+            alter_dict(
+                TEMPLATE,
+                "/ENTRY[my_entry]/NXODD_name[nxodd_name]/DATA[data]",
+                {
+                    "link": "/my_entry/nxodd_name/posint_value",
+                    "shape": (slice(0, 2),),
+                },
+            ),
+            "",
+            id="nxdata-signal-link-with-shape-written-as-real-vds",
+        ),
     ],
 )
 def test_validate_nexus_file(data_dict, error_messages, caplog, tmp_path, request):
@@ -3685,6 +3733,17 @@ def test_validate_nexus_file(data_dict, error_messages, caplog, tmp_path, reques
     _, nxdl_path = get_nxdl_root_and_path(nxdl=nxdl_name)
     hdf_file_path = tmp_path / f"hdf5_validator_test_{request.node.callspec.id}.nxs"
     Writer(data=template, nxdl_f_path=nxdl_path, output_path=hdf_file_path).write()
+
+    if request.node.callspec.id == "nxdata-signal-link-with-shape-written-as-real-vds":
+        # ValidationVisitor (via validate()) runs on the already-written file, where
+        # links/VDS are real h5py objects - it should see a correctly sliced VDS,
+        # not the full (unsliced) target the writer would fall back to if a bug
+        # upstream (e.g. in validate_dict_against) had corrupted the link/shape
+        # template entry before Writer ever ran.
+        with h5py.File(hdf_file_path, "r") as hdf_file:
+            dataset = hdf_file["/my_entry/nxodd_name/data"]
+            assert dataset.is_virtual
+            assert dataset.shape == (2,)
 
     if not error_messages:
         with caplog.at_level(logging.WARNING):

--- a/tests/dataconverter/test_validation.py
+++ b/tests/dataconverter/test_validation.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+from collections.abc import Mapping
 
 import h5py
 import numpy as np
@@ -2264,22 +2265,13 @@ def test_validate_data_dict(data_dict, error_messages, caplog, request):
 
     if not error_messages:
         link_path = "/ENTRY[my_entry]/NXODD_name[nxodd_name]/DATA[data]"
-        original_value = (
-            data_dict["required"].get(link_path)
-            if request.node.callspec.id
-            in (
-                "nxdata-signal-link-with-shape-not-mutated",
-                "list-form-vds-link-not-misclassified",
-            )
-            else None
-        )
+        original_value = data_dict["required"].get(link_path)
         with caplog.at_level(logging.WARNING):
             assert validate_dict_against("NXtest", data_dict)
         assert caplog.text == ""
-        if original_value is not None:
-            # validate_dict_against() resolves a {"link": ...} entry to check its
-            # type/shape against the schema, but must leave the original link (and
-            # any VDS "shape" slice) in the template - the Writer needs it intact.
+        if isinstance(original_value, Mapping) and "link" in original_value:
+            # A {"link": ...} entry (and any VDS "shape" slice) must survive
+            # validation unchanged - the Writer needs it intact.
             assert data_dict["required"][link_path] == original_value
     else:
         if request.node.callspec.id in (


### PR DESCRIPTION
Fixes #825.

## Summary
- `handle_field` in `validate_dict_against()` resolved `{"link": ...}` values for local type/shape checking, then wrote the resolved value back into the live `Template`, destroying the original link (and any VDS `"shape"` slice) before `Writer` ran.
- An `if`/`if`/`else` (should be `if`/`elif`/`else`) in the NXdata group dispatch caused NXdata groups to be processed twice, reintroducing the same corruption via the generic fallback path.
- List-form multi-source VDS links (`{"link": [...]}`) were misclassified as an invalid nested structure.

## Tests
- [x] Added 3 regression cases to the existing `test_validate_data_dict`/`test_validate_nexus_file` parametrized suites in `tests/dataconverter/test_validation.py`
- [x] Verified end-to-end against `pynxtools-ellips`'s real example: `Psi_50deg` now a correctly shaped `(1088,)` virtual dataset matching its axis, no more `NXdataAxisMismatch`