### PR TITLE
fix additive-write check for generator

### DIFF
--- a/src/pynxtools/nomad/converters/nxdl_to_metainfo.py
+++ b/src/pynxtools/nomad/converters/nxdl_to_metainfo.py
@@ -1945,23 +1945,35 @@ def render(context: dict, out_path: Path | None = None) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _existing_member_names(source: str) -> set[str]:
-    """Parse a Python source file and return top-level class member names."""
+def _class_member_sources(source: str) -> dict[str, str]:
+    """Parse a Python source file and return {member_name: source_text} for
+    every top-level class member (Quantity/SubSection assignment or method).
+
+    Source text, not just presence, matters: every generated class always
+    defines ``normalize()``, so a name-only comparison can't tell a
+    hand-edited body from a freshly generated one — both use the same name.
+    """
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return set()
-    names: set[str] = set()
+        return {}
+    members: dict[str, str] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef):
             for child in node.body:
+                name: str | None = None
                 if isinstance(child, ast.Assign):
                     for target in child.targets:
                         if isinstance(target, ast.Name):
-                            names.add(target.id)
+                            name = target.id
                 elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    names.add(child.name)
-    return names
+                    name = child.name
+                if name is None:
+                    continue
+                segment = ast.get_source_segment(source, child)
+                if segment is not None:
+                    members[name] = segment
+    return members
 
 
 def write_class(
@@ -1974,6 +1986,10 @@ def write_class(
 
     Returns True if the file content changed (or was created), False if unchanged.
     In dry_run mode: returns True if the file would differ, raises nothing.
+
+    Without ``force``, a file is left untouched if it has a member the fresh
+    template doesn't, or a shared member (e.g. ``normalize()``) whose content
+    was hand-edited to differ from the template's own version.
 
     output_dir should be the parent of base_classes/ and applications/ — the generator
     appends the correct subfolder automatically. Defaults to the pynxtools-internal
@@ -2006,10 +2022,15 @@ def write_class(
         else:
             if existing_source == new_source:
                 return False
-            existing_members = _existing_member_names(existing_source)
-            new_members = _existing_member_names(new_source)
-            user_added = existing_members - new_members
-            if user_added:
+            existing_members = _class_member_sources(existing_source)
+            new_members = _class_member_sources(new_source)
+            user_added = existing_members.keys() - new_members.keys()
+            user_modified = {
+                name
+                for name in existing_members.keys() & new_members.keys()
+                if existing_members[name] != new_members[name]
+            }
+            if user_added or user_modified:
                 return False
 
     if dry_run:

--- a/tests/nomad/test_nxdl_to_metainfo.py
+++ b/tests/nomad/test_nxdl_to_metainfo.py
@@ -38,6 +38,7 @@ files in ``tests/data/nomad/converter/``.
 """
 
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
@@ -352,18 +353,35 @@ def test_build_context_reserved_quantity_names_are_suffixed(
     assert quantity_names == [expected_name]
 
 
-def test_write_base_class_dry_run_detects_content_change(monkeypatch, tmp_path):
-    """A dry run reports a content difference without writing the file."""
+@pytest.fixture
+def stub_write_base_class(monkeypatch, tmp_path) -> Callable[[str, str], Path]:
+    """Stub ``build_context``/``render`` for ``write_base_class("NXentry", ...)``.
 
+    Returns a ``seed(existing_content, new_content)`` helper: writes
+    ``existing_content`` to the would-be output file, makes ``render`` return
+    ``new_content``, and returns the file's path. Callers still pass
+    ``output_dir=tmp_path`` to ``write_base_class`` themselves.
+    """
     out_dir = tmp_path / "base_classes"
     out_dir.mkdir(parents=True)
-    existing = out_dir / "entry.py"
-    existing.write_text("old content\n", encoding="utf-8")
-
     monkeypatch.setattr(converter, "build_context", lambda _: {"class_name": "Entry"})
-    monkeypatch.setattr(
-        converter, "render", lambda _context, out_path=None: "new content\n"
-    )
+
+    def seed(existing_content: str, new_content: str) -> Path:
+        monkeypatch.setattr(
+            converter, "render", lambda _context, out_path=None: new_content
+        )
+        existing = out_dir / "entry.py"
+        existing.write_text(existing_content, encoding="utf-8")
+        return existing
+
+    return seed
+
+
+def test_write_base_class_dry_run_detects_content_change(
+    stub_write_base_class, tmp_path
+):
+    """A dry run reports a content difference without writing the file."""
+    existing = stub_write_base_class("old content\n", "new content\n")
 
     changed = converter.write_base_class(
         "NXentry", dry_run=True, force=False, output_dir=tmp_path
@@ -373,6 +391,45 @@ def test_write_base_class_dry_run_detects_content_change(monkeypatch, tmp_path):
     # "Dry run" is the other half of the contract: the difference is reported,
     # but the file on disk still holds its original content.
     assert existing.read_text(encoding="utf-8") == "old content\n"
+
+
+@pytest.mark.parametrize(
+    "force,expect_written",
+    [
+        pytest.param(False, False, id="preserved-without-force"),
+        pytest.param(True, True, id="overwritten-with-force"),
+    ],
+)
+def test_write_base_class_hand_edited_shared_member(
+    stub_write_base_class, tmp_path, force, expect_written
+):
+    """Check that hand-edited members are preserved unless ``force=True``.
+
+    The generator always emits a generic ``normalize()`` implementation. Once a
+    user edits that generated stub, subsequent generations must preserve the
+    modified implementation instead of replacing it with a freshly generated one,
+    unless ``force=True``.
+    """
+    existing_source = (
+        "class Entry:\n"
+        "    def normalize(self, archive, logger):\n"
+        "        self.name = self.title\n"
+        "        super().normalize(archive, logger)\n"
+    )
+    fresh_source = (
+        "class Entry:\n"
+        "    def normalize(self, archive, logger):\n"
+        "        super().normalize(archive, logger)\n"
+    )
+    existing = stub_write_base_class(existing_source, fresh_source)
+
+    changed = converter.write_base_class(
+        "NXentry", dry_run=False, force=force, output_dir=tmp_path
+    )
+
+    assert changed is expect_written
+    expected = fresh_source if expect_written else existing_source
+    assert existing.read_text(encoding="utf-8") == expected
 
 
 def test_generate_all_base_classes_counts_only_changed(monkeypatch, tmp_path):


### PR DESCRIPTION
If `force=False` in the generator, any changes to the `normalize()` (or any other) method should not be overwritten. However, the existing additive-only guard only checked for differences for _names_ of the class members, not in their body. This PR fixes tht by comparing each shared member's source text, not just its name. member present in both files but with different content now counts as user-modified, exactly like a member absent from the template counts as user-added, and blocks the overwrite the same way.

Also adds more comprehensive tests for this overwrite functionality.